### PR TITLE
Deprecate Pragma

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -1146,7 +1146,7 @@
    </c>
    <c>Pragma</c>
    <c>http</c>
-   <c>standard</c>
+   <c>obsoleted</c>
    <c>
       <xref target="header.pragma"/>
    </c>
@@ -1798,51 +1798,18 @@
    <x:anchor-alias value="Pragma"/>
    <x:anchor-alias value="pragma-directive"/>
 <t>
-   The "Pragma" header field allows backwards compatibility with HTTP/1.0
-   caches, so that clients can specify a "no-cache" request that they will
-   understand (as <x:ref>Cache-Control</x:ref> was not defined until HTTP/1.1).
-   When the Cache-Control header field is also present and understood in a
-   request, Pragma is ignored.
+   The "Pragma" header field was defined for HTTP/1.0 caches, so that clients
+   could specify a "no-cache" request (as <x:ref>Cache-Control</x:ref> was
+   not defined until HTTP/1.1).
 </t>
 <t>
-   In HTTP/1.0, Pragma was defined as an extensible field for
-   implementation-specified directives for recipients. This specification
-   deprecates such extensions to improve interoperability.
+   However, support for Cache-Control is now widespread. As a result, this
+   specification deprecates Pragma.
 </t>
-<figure><artwork type="abnf2616"><iref primary="true" item="Grammar" subitem="Pragma"/><iref primary="true" item="Grammar" subitem="pragma-directive"/><iref primary="true" item="Grammar" subitem="extension-pragma"/>
-  <x:ref>Pragma</x:ref>           = 1#<x:ref>pragma-directive</x:ref>
-  <x:ref>pragma-directive</x:ref> = "no-cache" / <x:ref>extension-pragma</x:ref>
-  <x:ref>extension-pragma</x:ref> = <x:ref>token</x:ref> [ "=" ( <x:ref>token</x:ref> / <x:ref>quoted-string</x:ref> ) ]
-</artwork></figure>
-<t>
-   When the <x:ref>Cache-Control</x:ref> header field is not present in a
-   request, caches &MUST; consider the no-cache request pragma-directive as
-   having the same effect as if "Cache-Control: no-cache" were present (see
-   <xref target="cache-request-directive" />).
-</t>
-<t>
-   When sending a no-cache request, a client ought to include both the pragma
-   and cache-control directives, unless Cache-Control: no-cache is
-   purposefully omitted to target other <x:ref>Cache-Control</x:ref> request
-   directives at HTTP/1.1 or greater caches. For example:
-</t>
-<figure>
-<artwork type="message/http; msgtype=&#34;response&#34;" x:indent-with="  ">
-GET / HTTP/1.1
-Host: www.example.com
-Cache-Control: max-age=30
-Pragma: no-cache
 
-</artwork>
-</figure>
-<t>
-   will constrain HTTP/1.1 and greater caches to serve a response no older
-   than 30 seconds, while precluding implementations that do not understand
-   <x:ref>Cache-Control</x:ref> from serving a cached response.
-</t>
 <aside>
    <t>
-      &Note; Because the meaning of "Pragma: no-cache" in responses is not
+      &Note; Because the meaning of "Pragma: no-cache" in responses was never
       specified, it does not provide a reliable replacement for
       "Cache-Control: no-cache" in them.
    </t>
@@ -2305,6 +2272,7 @@ Pragma: no-cache
 <ul>
    <li>In <xref target="cache-response-directive"/>, note effect of some directives on authenticated requests (<eref target="https://github.com/httpwg/http-core/issues/161"/>)</li>
    <li>In <xref target="constructing.responses.from.caches"/>, clarify language around how to select a response when more than one matches (<eref target="https://github.com/httpwg/http-core/issues/23"/>)</li>
+   <li>Deprecate Pragma (<eref target="https://github.com/httpwg/http-core/issues/140"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
Fixes #140.

Note that there's one more reference to pragma remaining, but that will be taken care of by #171.