### PR TITLE
Start #165: list non-cached and non-updated header fields

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -384,6 +384,39 @@
    prohibited from storing such responses.
 </t>
 
+<section title="Storing Response Header Fields" anchor="storing.headers">
+<t>
+   When storing a response, a cache &MUST; omit header fields in the following
+   categories:
+</t>
+<ul>
+   <li>Hop-by-hop header fields listed in the Connection header field (<xref
+      target="header.connection" />).</li>
+   <li>Header fields listed in the no-cache response directive in the Cache-Control
+      header field (<xref target="cache-response-directive.no-cache" />).</li>
+   <li>Header fields whose name appears in the following list:
+      <ul>
+         <li>Clear-Site-Data</li>
+         <li>Connection</li>
+         <li>Keep-Alive</li>
+         <li>Proxy-Authenticate</li>
+         <li>Proxy-Connection</li>
+         <li>Public-Key-Pins</li>
+         <li>Set-Cookie</li>
+         <li>Set-Cookie2</li>
+         <li>Strict-Transport-Security</li>
+         <li>Trailer</li>
+         <li>Transfer-Encoding</li>
+         <li>Upgrade</li>
+         <li>WWW-Authenticate</li>
+      </ul>
+   </li>
+</ul>
+<t>
+   TODO: The above list is not final.
+</t>
+</section>
+
 <section title="Storing Incomplete Responses" anchor="incomplete.responses">
 <t>
    A response message is considered complete when all of the octets indicated
@@ -1027,7 +1060,8 @@
    For each stored response identified for update, the cache &MUST; use the
    header fields provided in the <x:ref>304 (Not Modified)</x:ref> response
    to replace all instances of the corresponding header fields in the stored
-   response.
+   response, except as provided by
+   <xref target="non-freshened.headers"/>.
 </t>
 </section>
 
@@ -1062,7 +1096,34 @@
    response to replace all instances of the corresponding header fields in
    the stored response and append new header fields to the stored response's
    header section unless otherwise restricted by the
-   <x:ref>Cache-Control</x:ref> header field.
+   <x:ref>Cache-Control</x:ref> header field or <xref
+   target="non-freshened.headers"/>.
+</t>
+</section>
+
+<section title="Header Fields That Aren't Freshened" anchor="non-freshened.headers">
+<t>
+   The following header fields are cached, but caches &MAY; choose not to update
+   them when a <x:ref>304 (Not Modified)</x:ref> response or a response to a
+   HEAD request is received:
+</t>
+<ul>
+   <li>Content-Encoding</li>
+   <li>Content-Length</li>
+   <li>Content-Location</li>
+   <li>Content-MD5</li>
+   <li>Content-Range</li>
+   <li>Content-Type</li>
+   <li>ETag</li>
+   <li>Proxy-Authorization</li>
+   <li>TE</li>
+   <li>X-Frame-Options</li>
+   <li>X-XSS-Protection</li>
+   <li>All header fields starting with "X-Content-"</li>
+   <li>All header fields starting with "X-Webkit-"</li>
+</ul>
+<t>
+   TODO: The above list is not final.
 </t>
 </section>
 </section>
@@ -1946,6 +2007,7 @@
   <reference anchor="Messaging">
     <x:source basename="draft-ietf-httpbis-messaging-latest" href="draft-ietf-httpbis-messaging-latest.xml">
       <x:has anchor="associating.response.to.request"/>
+      <x:has anchor="header.connection"/>
       <x:has anchor="message.body.length"/>
     </x:source>
   </reference>


### PR DESCRIPTION
Debate continues about exactly which headers should be included in these
lists, so my goal in this change is just to record the status quo
without expressing any opinion that it's a good status quo.

@MattMenke2, Chrome's failing the "update Content-Test-Header" test in https://wpt.fyi/results/fetch/http-cache/304-update.html?aligned&label=stable, but I don't see code in https://cs.chromium.org/chromium/src/net/http/http_response_headers.cc to do that. Any idea what's going on?