### PR TITLE
transfer-coding: remove the predefined codings from the ABNF and make  it generic instead (see #66)

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.html
+++ b/draft-ietf-httpbis-messaging-latest.html
@@ -1706,17 +1706,12 @@ Host: www.example.org
                is a property of the message rather than a property of the representation that is
                being transferred.<a class="self" href="#rfc.section.7.p.1">¶</a></p>
          </div>
-         <div id="rfc.section.7.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.25"></span><span id="rfc.iref.g.26"></span>  <a href="#transfer.codings" class="smpl">transfer-coding</a>    = "chunked" ; <a href="#chunked.encoding" title="Chunked Transfer Coding">Section&nbsp;7.1</a>
-                     / "compress" ; <a href="#Semantics" id="rfc.xref.Semantics.34"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#compress.coding" title="Compress Coding">Section 6.1.2.1</a>
-                     / "deflate" ; <a href="#Semantics" id="rfc.xref.Semantics.35"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#deflate.coding" title="Deflate Coding">Section 6.1.2.2</a>
-                     / "gzip" ; <a href="#Semantics" id="rfc.xref.Semantics.36"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#gzip.coding" title="Gzip Coding">Section 6.1.2.3</a>
-                     / <a href="#transfer.codings" class="smpl">transfer-extension</a>
-  <a href="#transfer.codings" class="smpl">transfer-extension</a> = <a href="#imported.rules" class="smpl">token</a> *( <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> ";" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> <a href="#rule.parameter" class="smpl">transfer-parameter</a> )
+         <div id="rfc.section.7.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.25"></span>  <a href="#transfer.codings" class="smpl">transfer-coding</a> = <a href="#imported.rules" class="smpl">token</a> *( <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> ";" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> <a href="#rule.parameter" class="smpl">transfer-parameter</a> )
 </pre></div>
          <div id="rfc.section.7.p.3">
             <p id="rule.parameter"> Parameters are in the form of a name=value pair.<a class="self" href="#rfc.section.7.p.3">¶</a></p>
          </div>
-         <div id="rfc.section.7.p.4"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.27"></span>  <a href="#rule.parameter" class="smpl">transfer-parameter</a> = <a href="#imported.rules" class="smpl">token</a> <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> "=" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> ( <a href="#imported.rules" class="smpl">token</a> / <a href="#imported.rules" class="smpl">quoted-string</a> )
+         <div id="rfc.section.7.p.4"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.26"></span>  <a href="#rule.parameter" class="smpl">transfer-parameter</a> = <a href="#imported.rules" class="smpl">token</a> <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> "=" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> ( <a href="#imported.rules" class="smpl">token</a> / <a href="#imported.rules" class="smpl">quoted-string</a> )
 </pre></div>
          <div id="rfc.section.7.p.5">
             <p>All transfer-coding names are case-insensitive and ought to be registered within the
@@ -1796,7 +1791,7 @@ Host: www.example.org
                   to retain connection persistence and the recipient to know when it has received the
                   entire message.<a class="self" href="#rfc.section.7.1.p.1">¶</a></p>
             </div>
-            <div id="rfc.section.7.1.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.28"></span><span id="rfc.iref.g.29"></span><span id="rfc.iref.g.30"></span><span id="rfc.iref.g.31"></span><span id="rfc.iref.g.32"></span><span id="rfc.iref.g.33"></span><span id="rfc.iref.g.34"></span>  <a href="#chunked.encoding" class="smpl">chunked-body</a>   = *<a href="#chunked.encoding" class="smpl">chunk</a>
+            <div id="rfc.section.7.1.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.27"></span><span id="rfc.iref.g.28"></span><span id="rfc.iref.g.29"></span><span id="rfc.iref.g.30"></span><span id="rfc.iref.g.31"></span><span id="rfc.iref.g.32"></span><span id="rfc.iref.g.33"></span>  <a href="#chunked.encoding" class="smpl">chunked-body</a>   = *<a href="#chunked.encoding" class="smpl">chunk</a>
                    <a href="#chunked.encoding" class="smpl">last-chunk</a>
                    <a href="#chunked.trailer.part" class="smpl">trailer-part</a>
                    <a href="#core.rules" class="smpl">CRLF</a>
@@ -1817,6 +1812,9 @@ Host: www.example.org
             <div id="rfc.section.7.1.p.4">
                <p>A recipient <em class="bcp14">MUST</em> be able to parse and decode the chunked transfer coding.<a class="self" href="#rfc.section.7.1.p.4">¶</a></p>
             </div>
+            <div id="rfc.section.7.1.p.5">
+               <p>The chunked encoding does not define any parameters. Their presence <em class="bcp14">SHOULD</em> be treated as an error.<a class="self" href="#rfc.section.7.1.p.5">¶</a></p>
+            </div>
             <section id="chunked.extension">
                <h4 id="rfc.section.7.1.1"><a href="#rfc.section.7.1.1">7.1.1.</a>&nbsp;<a href="#chunked.extension">Chunk Extensions</a></h4>
                <div id="rfc.section.7.1.1.p.1">
@@ -1824,7 +1822,7 @@ Host: www.example.org
                      following the <a href="#chunked.encoding" class="smpl">chunk-size</a>, for the sake of supplying per-chunk metadata (such as a signature or hash), mid-message
                      control information, or randomization of message body size.<a class="self" href="#rfc.section.7.1.1.p.1">¶</a></p>
                </div>
-               <div id="rfc.section.7.1.1.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.35"></span><span id="rfc.iref.g.36"></span><span id="rfc.iref.g.37"></span>  <a href="#chunked.extension" class="smpl">chunk-ext</a>      = *( <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> ";" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> <a href="#chunked.extension" class="smpl">chunk-ext-name</a>
+               <div id="rfc.section.7.1.1.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.34"></span><span id="rfc.iref.g.35"></span><span id="rfc.iref.g.36"></span>  <a href="#chunked.extension" class="smpl">chunk-ext</a>      = *( <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> ";" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> <a href="#chunked.extension" class="smpl">chunk-ext-name</a>
                       [ <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> "=" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> <a href="#chunked.extension" class="smpl">chunk-ext-val</a> ] )
 
   <a href="#chunked.extension" class="smpl">chunk-ext-name</a> = <a href="#imported.rules" class="smpl">token</a>
@@ -1854,10 +1852,10 @@ Host: www.example.org
                      status. The trailer fields are identical to header fields, except they are sent in
                      a chunked trailer instead of the message's header section.<a class="self" href="#rfc.section.7.1.2.p.1">¶</a></p>
                </div>
-               <div id="rfc.section.7.1.2.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.38"></span><span id="rfc.iref.g.39"></span>  <a href="#chunked.trailer.part" class="smpl">trailer-part</a>   = *( <a href="#header.fields" class="smpl">header-field</a> <a href="#core.rules" class="smpl">CRLF</a> )
+               <div id="rfc.section.7.1.2.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.37"></span><span id="rfc.iref.g.38"></span>  <a href="#chunked.trailer.part" class="smpl">trailer-part</a>   = *( <a href="#header.fields" class="smpl">header-field</a> <a href="#core.rules" class="smpl">CRLF</a> )
 </pre></div>
                <div id="rfc.section.7.1.2.p.3">
-                  <p>A sender <em class="bcp14">MUST NOT</em> generate a trailer that contains a field necessary for message framing (e.g., <a href="#header.transfer-encoding" class="smpl">Transfer-Encoding</a> and <a href="#body.content-length" class="smpl">Content-Length</a>), routing (e.g., <a href="draft-ietf-httpbis-semantics-latest.html#header.host" class="smpl">Host</a>), request modifiers (e.g., controls and conditionals in <a href="draft-ietf-httpbis-semantics-latest.html#request.header.fields" title="Request Header Fields">Section 8</a> of <a href="#Semantics" id="rfc.xref.Semantics.37"><cite title="HTTP Semantics">[Semantics]</cite></a>), authentication (e.g., see <a href="draft-ietf-httpbis-semantics-latest.html#request.auth" title="Authentication Credentials">Section 8.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.38"><cite title="HTTP Semantics">[Semantics]</cite></a> and <a href="#RFC6265" id="rfc.xref.RFC6265.1"><cite title="HTTP State Management Mechanism">[RFC6265]</cite></a>), response control data (e.g., see <a href="draft-ietf-httpbis-semantics-latest.html#response.control.data" title="Control Data">Section 10.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.39"><cite title="HTTP Semantics">[Semantics]</cite></a>), or determining how to process the payload (e.g., <a href="draft-ietf-httpbis-semantics-latest.html#header.content-encoding" class="smpl">Content-Encoding</a>, <a href="draft-ietf-httpbis-semantics-latest.html#header.content-type" class="smpl">Content-Type</a>, <a href="draft-ietf-httpbis-semantics-latest.html#header.content-range" class="smpl">Content-Range</a>, and <a href="draft-ietf-httpbis-semantics-latest.html#header.trailer" class="smpl">Trailer</a>).<a class="self" href="#rfc.section.7.1.2.p.3">¶</a></p>
+                  <p>A sender <em class="bcp14">MUST NOT</em> generate a trailer that contains a field necessary for message framing (e.g., <a href="#header.transfer-encoding" class="smpl">Transfer-Encoding</a> and <a href="#body.content-length" class="smpl">Content-Length</a>), routing (e.g., <a href="draft-ietf-httpbis-semantics-latest.html#header.host" class="smpl">Host</a>), request modifiers (e.g., controls and conditionals in <a href="draft-ietf-httpbis-semantics-latest.html#request.header.fields" title="Request Header Fields">Section 8</a> of <a href="#Semantics" id="rfc.xref.Semantics.34"><cite title="HTTP Semantics">[Semantics]</cite></a>), authentication (e.g., see <a href="draft-ietf-httpbis-semantics-latest.html#request.auth" title="Authentication Credentials">Section 8.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.35"><cite title="HTTP Semantics">[Semantics]</cite></a> and <a href="#RFC6265" id="rfc.xref.RFC6265.1"><cite title="HTTP State Management Mechanism">[RFC6265]</cite></a>), response control data (e.g., see <a href="draft-ietf-httpbis-semantics-latest.html#response.control.data" title="Control Data">Section 10.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.36"><cite title="HTTP Semantics">[Semantics]</cite></a>), or determining how to process the payload (e.g., <a href="draft-ietf-httpbis-semantics-latest.html#header.content-encoding" class="smpl">Content-Encoding</a>, <a href="draft-ietf-httpbis-semantics-latest.html#header.content-type" class="smpl">Content-Type</a>, <a href="draft-ietf-httpbis-semantics-latest.html#header.content-range" class="smpl">Content-Range</a>, and <a href="draft-ietf-httpbis-semantics-latest.html#header.trailer" class="smpl">Trailer</a>).<a class="self" href="#rfc.section.7.1.2.p.3">¶</a></p>
                </div>
                <div id="rfc.section.7.1.2.p.4">
                   <p>When a chunked message containing a non-empty trailer is received, the recipient <em class="bcp14">MAY</em> process the fields (aside from those forbidden above) as if they were appended to
@@ -1917,17 +1915,20 @@ Host: www.example.org
                   as their corresponding content coding:<a class="self" href="#rfc.section.7.2.p.1">¶</a></p>
             </div>
             <div id="rfc.section.7.2.p.2">
-               <dl>
+               <dl class="nohang">
                   <dt>compress (and x-compress)</dt>
-                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#compress.coding" title="Compress Coding">Section 6.1.2.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.40"><cite title="HTTP Semantics">[Semantics]</cite></a>.
+                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#compress.coding" title="Compress Coding">Section 6.1.2.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.37"><cite title="HTTP Semantics">[Semantics]</cite></a>.
                   </dd>
                   <dt>deflate</dt>
-                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#deflate.coding" title="Deflate Coding">Section 6.1.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.41"><cite title="HTTP Semantics">[Semantics]</cite></a>.
+                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#deflate.coding" title="Deflate Coding">Section 6.1.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.38"><cite title="HTTP Semantics">[Semantics]</cite></a>.
                   </dd>
                   <dt>gzip (and x-gzip)</dt>
-                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#gzip.coding" title="Gzip Coding">Section 6.1.2.3</a> of <a href="#Semantics" id="rfc.xref.Semantics.42"><cite title="HTTP Semantics">[Semantics]</cite></a>.
+                  <dd>See <a href="draft-ietf-httpbis-semantics-latest.html#gzip.coding" title="Gzip Coding">Section 6.1.2.3</a> of <a href="#Semantics" id="rfc.xref.Semantics.39"><cite title="HTTP Semantics">[Semantics]</cite></a>.
                   </dd>
                </dl>
+            </div>
+            <div id="rfc.section.7.2.p.3">
+               <p>The compression codings do not define any parameters. Their presence <em class="bcp14">SHOULD</em> be treated as an error.<a class="self" href="#rfc.section.7.2.p.3">¶</a></p>
             </div>
          </section>
          <section id="transfer.coding.registry">
@@ -1947,7 +1948,7 @@ Host: www.example.org
                </ul>
             </div>
             <div id="rfc.section.7.3.p.4">
-               <p>Names of transfer codings <em class="bcp14">MUST NOT</em> overlap with names of content codings (<a href="draft-ietf-httpbis-semantics-latest.html#content.codings" title="Content Codings">Section 6.1.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.43"><cite title="HTTP Semantics">[Semantics]</cite></a>) unless the encoding transformation is identical, as is the case for the compression
+               <p>Names of transfer codings <em class="bcp14">MUST NOT</em> overlap with names of content codings (<a href="draft-ietf-httpbis-semantics-latest.html#content.codings" title="Content Codings">Section 6.1.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.40"><cite title="HTTP Semantics">[Semantics]</cite></a>) unless the encoding transformation is identical, as is the case for the compression
                   codings defined in <a href="#compression.codings" title="Transfer Codings for Compression">Section&nbsp;7.2</a>.<a class="self" href="#rfc.section.7.3.p.4">¶</a></p>
             </div>
             <div id="rfc.section.7.3.p.5">
@@ -1974,7 +1975,7 @@ Host: www.example.org
                   allowing for optional parameters (as described in <a href="#transfer.codings" title="Transfer Codings">Section&nbsp;7</a>), and/or the keyword "trailers". A client <em class="bcp14">MUST NOT</em> send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1
                   recipients.<a class="self" href="#rfc.section.7.4.p.2">¶</a></p>
             </div>
-            <div id="rfc.section.7.4.p.3"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.40"></span><span id="rfc.iref.g.41"></span><span id="rfc.iref.g.42"></span><span id="rfc.iref.g.43"></span>  <a href="#header.te" class="smpl">TE</a>        = #<a href="#header.te" class="smpl">t-codings</a>
+            <div id="rfc.section.7.4.p.3"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.39"></span><span id="rfc.iref.g.40"></span><span id="rfc.iref.g.41"></span><span id="rfc.iref.g.42"></span>  <a href="#header.te" class="smpl">TE</a>        = #<a href="#header.te" class="smpl">t-codings</a>
   <a href="#header.te" class="smpl">t-codings</a> = "trailers" / ( <a href="#transfer.codings" class="smpl">transfer-coding</a> [ <a href="#header.te" class="smpl">t-ranking</a> ] )
   <a href="#header.te" class="smpl">t-ranking</a> = <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> ";" <a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> "q=" <a href="#header.te" class="smpl">rank</a>
   <a href="#header.te" class="smpl">rank</a>      = ( "0" [ "." 0*3<a href="#core.rules" class="smpl">DIGIT</a> ] )
@@ -1998,7 +1999,7 @@ Host: www.example.org
             </div>
             <div id="rfc.section.7.4.p.7">
                <p>When multiple transfer codings are acceptable, the client <em class="bcp14">MAY</em> rank the codings by preference using a case-insensitive "q" parameter (similar to
-                  the qvalues used in content negotiation fields, <a href="draft-ietf-httpbis-semantics-latest.html#quality.values" title="Quality Values">Section 8.4.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.44"><cite title="HTTP Semantics">[Semantics]</cite></a>). The rank value is a real number in the range 0 through 1, where 0.001 is the least
+                  the qvalues used in content negotiation fields, <a href="draft-ietf-httpbis-semantics-latest.html#quality.values" title="Quality Values">Section 8.4.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.41"><cite title="HTTP Semantics">[Semantics]</cite></a>). The rank value is a real number in the range 0 through 1, where 0.001 is the least
                   preferred and 1 is the most preferred; a value of 0 means "not acceptable".<a class="self" href="#rfc.section.7.4.p.7">¶</a></p>
             </div>
             <div id="rfc.section.7.4.p.8">
@@ -2048,8 +2049,8 @@ Host: www.example.org
                outside the scope of this specification.<a class="self" href="#rfc.section.9.p.1">¶</a></p>
          </div>
          <div id="rfc.section.9.p.2">
-            <p>As described in <a href="draft-ietf-httpbis-semantics-latest.html#routing.inbound" title="Routing Inbound">Section 5.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.45"><cite title="HTTP Semantics">[Semantics]</cite></a>, the specific connection protocols to be used for an HTTP interaction are determined
-               by client configuration and the <a href="draft-ietf-httpbis-semantics-latest.html#target.resource" class="smpl">target URI</a>. For example, the "http" URI scheme (<a href="draft-ietf-httpbis-semantics-latest.html#http.uri" title="http URI Scheme">Section 2.5.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.46"><cite title="HTTP Semantics">[Semantics]</cite></a>) indicates a default connection of TCP over IP, with a default TCP port of 80, but
+            <p>As described in <a href="draft-ietf-httpbis-semantics-latest.html#routing.inbound" title="Routing Inbound">Section 5.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.42"><cite title="HTTP Semantics">[Semantics]</cite></a>, the specific connection protocols to be used for an HTTP interaction are determined
+               by client configuration and the <a href="draft-ietf-httpbis-semantics-latest.html#target.resource" class="smpl">target URI</a>. For example, the "http" URI scheme (<a href="draft-ietf-httpbis-semantics-latest.html#http.uri" title="http URI Scheme">Section 2.5.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.43"><cite title="HTTP Semantics">[Semantics]</cite></a>) indicates a default connection of TCP over IP, with a default TCP port of 80, but
                the client might be configured to use a proxy via some other connection, port, or
                protocol.<a class="self" href="#rfc.section.9.p.2">¶</a></p>
          </div>
@@ -2087,7 +2088,7 @@ Host: www.example.org
             <div id="rfc.section.9.1.p.4" class="avoidbreakafter">
                <p>The Connection header field's value has the following grammar:<a class="self" href="#rfc.section.9.1.p.4">¶</a></p>
             </div>
-            <div id="rfc.section.9.1.p.5"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.44"></span><span id="rfc.iref.g.45"></span>  <a href="#header.connection" class="smpl">Connection</a>        = 1#<a href="#header.connection" class="smpl">connection-option</a>
+            <div id="rfc.section.9.1.p.5"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.43"></span><span id="rfc.iref.g.44"></span>  <a href="#header.connection" class="smpl">Connection</a>        = 1#<a href="#header.connection" class="smpl">connection-option</a>
   <a href="#header.connection" class="smpl">connection-option</a> = <a href="#imported.rules" class="smpl">token</a>
 </pre></div>
             <div id="rfc.section.9.1.p.6">
@@ -2145,7 +2146,7 @@ Host: www.example.org
                   with its corresponding one or more response messages. Hence, it relies on the order
                   of response arrival to correspond exactly to the order in which requests are made
                   on the same connection. More than one response message per request only occurs when
-                  one or more informational responses (<a href="draft-ietf-httpbis-semantics-latest.html#status.1xx" class="smpl">1xx</a>, see <a href="draft-ietf-httpbis-semantics-latest.html#status.1xx" title="Informational 1xx">Section 9.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.47"><cite title="HTTP Semantics">[Semantics]</cite></a>) precede a final response to the same request.<a class="self" href="#rfc.section.9.3.p.1">¶</a></p>
+                  one or more informational responses (<a href="draft-ietf-httpbis-semantics-latest.html#status.1xx" class="smpl">1xx</a>, see <a href="draft-ietf-httpbis-semantics-latest.html#status.1xx" title="Informational 1xx">Section 9.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.44"><cite title="HTTP Semantics">[Semantics]</cite></a>) precede a final response to the same request.<a class="self" href="#rfc.section.9.3.p.1">¶</a></p>
             </div>
             <div id="rfc.section.9.3.p.2">
                <p>A client that has more than one outstanding request on a connection <em class="bcp14">MUST</em> maintain a list of outstanding requests in the order sent and <em class="bcp14">MUST</em> associate each received response message on that connection to the highest ordered
@@ -2206,7 +2207,7 @@ Host: www.example.org
                </div>
                <div id="rfc.section.9.4.1.p.2">
                   <p>When an inbound connection is closed prematurely, a client <em class="bcp14">MAY</em> open a new connection and automatically retransmit an aborted sequence of requests
-                     if all of those requests have idempotent methods (<a href="draft-ietf-httpbis-semantics-latest.html#idempotent.methods" title="Idempotent Methods">Section 7.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.48"><cite title="HTTP Semantics">[Semantics]</cite></a>). A proxy <em class="bcp14">MUST NOT</em> automatically retry non-idempotent requests.<a class="self" href="#rfc.section.9.4.1.p.2">¶</a></p>
+                     if all of those requests have idempotent methods (<a href="draft-ietf-httpbis-semantics-latest.html#idempotent.methods" title="Idempotent Methods">Section 7.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.45"><cite title="HTTP Semantics">[Semantics]</cite></a>). A proxy <em class="bcp14">MUST NOT</em> automatically retry non-idempotent requests.<a class="self" href="#rfc.section.9.4.1.p.2">¶</a></p>
                </div>
                <div id="rfc.section.9.4.1.p.3">
                   <p>A user agent <em class="bcp14">MUST NOT</em> automatically retry a request with a non-idempotent method unless it has some means
@@ -2228,7 +2229,7 @@ Host: www.example.org
                <div id="rfc.section.9.4.2.p.1">
                   <p>A client that supports persistent connections <em class="bcp14">MAY</em> "<dfn>pipeline</dfn>" its requests (i.e., send multiple requests without waiting for each response). A
                      server <em class="bcp14">MAY</em> process a sequence of pipelined requests in parallel if they all have safe methods
-                     (<a href="draft-ietf-httpbis-semantics-latest.html#safe.methods" title="Safe Methods">Section 7.2.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.49"><cite title="HTTP Semantics">[Semantics]</cite></a>), but it <em class="bcp14">MUST</em> send the corresponding responses in the same order that the requests were received.<a class="self" href="#rfc.section.9.4.2.p.1">¶</a></p>
+                     (<a href="draft-ietf-httpbis-semantics-latest.html#safe.methods" title="Safe Methods">Section 7.2.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.46"><cite title="HTTP Semantics">[Semantics]</cite></a>), but it <em class="bcp14">MUST</em> send the corresponding responses in the same order that the requests were received.<a class="self" href="#rfc.section.9.4.2.p.1">¶</a></p>
                </div>
                <div id="rfc.section.9.4.2.p.2">
                   <p>A client that pipelines requests <em class="bcp14">SHOULD</em> retry unanswered requests if the connection closes before it receives all of the corresponding
@@ -2239,7 +2240,7 @@ Host: www.example.org
                      described in <a href="#persistent.tear-down" id="rfc.xref.persistent.tear-down.2" title="Tear-down">Section&nbsp;9.7</a>).<a class="self" href="#rfc.section.9.4.2.p.2">¶</a></p>
                </div>
                <div id="rfc.section.9.4.2.p.3">
-                  <p>Idempotent methods (<a href="draft-ietf-httpbis-semantics-latest.html#idempotent.methods" title="Idempotent Methods">Section 7.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.50"><cite title="HTTP Semantics">[Semantics]</cite></a>) are significant to pipelining because they can be automatically retried after a
+                  <p>Idempotent methods (<a href="draft-ietf-httpbis-semantics-latest.html#idempotent.methods" title="Idempotent Methods">Section 7.2.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.47"><cite title="HTTP Semantics">[Semantics]</cite></a>) are significant to pipelining because they can be automatically retried after a
                      connection failure. A user agent <em class="bcp14">SHOULD NOT</em> pipeline requests after a non-idempotent method, until the final response status code
                      for that method has been received, unless the user agent has a means to detect and
                      recover from partial failure conditions involving the pipelined sequence.<a class="self" href="#rfc.section.9.4.2.p.3">¶</a></p>
@@ -2363,7 +2364,7 @@ Host: www.example.org
                   sending the final response. A server <em class="bcp14">MAY</em> ignore a received Upgrade header field if it wishes to continue using the current
                   protocol on that connection. Upgrade cannot be used to insist on a protocol change.<a class="self" href="#rfc.section.9.8.p.1">¶</a></p>
             </div>
-            <div id="rfc.section.9.8.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.46"></span>  <a href="#header.upgrade" class="smpl">Upgrade</a>          = 1#<a href="#header.upgrade" class="smpl">protocol</a>
+            <div id="rfc.section.9.8.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.45"></span>  <a href="#header.upgrade" class="smpl">Upgrade</a>          = 1#<a href="#header.upgrade" class="smpl">protocol</a>
 
   <a href="#header.upgrade" class="smpl">protocol</a>         = <a href="#header.upgrade" class="smpl">protocol-name</a> ["/" <a href="#header.upgrade" class="smpl">protocol-version</a>]
   <a href="#header.upgrade" class="smpl">protocol-name</a>    = <a href="#imported.rules" class="smpl">token</a>
@@ -2428,19 +2429,19 @@ Upgrade: HTTP/2.0
             <div id="rfc.section.9.8.p.13">
                <p>A client cannot begin using an upgraded protocol on the connection until it has completely
                   sent the request message (i.e., the client can't change the protocol it is sending
-                  in the middle of a message). If a server receives both an Upgrade and an <a href="draft-ietf-httpbis-semantics-latest.html#header.expect" class="smpl">Expect</a> header field with the "100-continue" expectation (<a href="draft-ietf-httpbis-semantics-latest.html#header.expect" title="Expect">Section 8.1.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.51"><cite title="HTTP Semantics">[Semantics]</cite></a>), the server <em class="bcp14">MUST</em> send a <a href="draft-ietf-httpbis-semantics-latest.html#status.100" class="smpl">100 (Continue)</a> response before sending a <a href="draft-ietf-httpbis-semantics-latest.html#status.101" class="smpl">101 (Switching Protocols)</a> response.<a class="self" href="#rfc.section.9.8.p.13">¶</a></p>
+                  in the middle of a message). If a server receives both an Upgrade and an <a href="draft-ietf-httpbis-semantics-latest.html#header.expect" class="smpl">Expect</a> header field with the "100-continue" expectation (<a href="draft-ietf-httpbis-semantics-latest.html#header.expect" title="Expect">Section 8.1.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.48"><cite title="HTTP Semantics">[Semantics]</cite></a>), the server <em class="bcp14">MUST</em> send a <a href="draft-ietf-httpbis-semantics-latest.html#status.100" class="smpl">100 (Continue)</a> response before sending a <a href="draft-ietf-httpbis-semantics-latest.html#status.101" class="smpl">101 (Switching Protocols)</a> response.<a class="self" href="#rfc.section.9.8.p.13">¶</a></p>
             </div>
             <div id="rfc.section.9.8.p.14">
                <p>The Upgrade header field only applies to switching protocols on top of the existing
                   connection; it cannot be used to switch the underlying connection (transport) protocol,
                   nor to switch the existing communication to a different connection. For those purposes,
-                  it is more appropriate to use a <a href="draft-ietf-httpbis-semantics-latest.html#status.3xx" class="smpl">3xx (Redirection)</a> response (<a href="draft-ietf-httpbis-semantics-latest.html#status.3xx" title="Redirection 3xx">Section 9.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.52"><cite title="HTTP Semantics">[Semantics]</cite></a>).<a class="self" href="#rfc.section.9.8.p.14">¶</a></p>
+                  it is more appropriate to use a <a href="draft-ietf-httpbis-semantics-latest.html#status.3xx" class="smpl">3xx (Redirection)</a> response (<a href="draft-ietf-httpbis-semantics-latest.html#status.3xx" title="Redirection 3xx">Section 9.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.49"><cite title="HTTP Semantics">[Semantics]</cite></a>).<a class="self" href="#rfc.section.9.8.p.14">¶</a></p>
             </div>
             <section id="upgrade.protocol.names">
                <h4 id="rfc.section.9.8.1"><a href="#rfc.section.9.8.1">9.8.1.</a>&nbsp;<a href="#upgrade.protocol.names">Upgrade Protocol Names</a></h4>
                <div id="rfc.section.9.8.1.p.1">
                   <p>This specification only defines the protocol name "HTTP" for use by the family of
-                     Hypertext Transfer Protocols, as defined by the HTTP version rules of <a href="draft-ietf-httpbis-semantics-latest.html#protocol.version" title="Protocol Versioning">Section 3.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.53"><cite title="HTTP Semantics">[Semantics]</cite></a> and future updates to this specification. Additional protocol names ought to be registered
+                     Hypertext Transfer Protocols, as defined by the HTTP version rules of <a href="draft-ietf-httpbis-semantics-latest.html#protocol.version" title="Protocol Versioning">Section 3.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.50"><cite title="HTTP Semantics">[Semantics]</cite></a> and future updates to this specification. Additional protocol names ought to be registered
                      using the registration procedure defined in <a href="#upgrade.token.registry" title="Upgrade Token Registry">Section&nbsp;9.8.2</a>.<a class="self" href="#rfc.section.9.8.1.p.1">¶</a></p>
                </div>
                <div id="rfc.table.u.2" class="tt">
@@ -2458,7 +2459,7 @@ Upgrade: HTTP/2.0
                            <td class="left">HTTP</td>
                            <td class="left">Hypertext Transfer Protocol</td>
                            <td class="left">any DIGIT.DIGIT (e.g, "2.0")</td>
-                           <td class="left"><a href="draft-ietf-httpbis-semantics-latest.html#protocol.version" title="Protocol Versioning">Section 3.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.54"><cite title="HTTP Semantics">[Semantics]</cite></a></td>
+                           <td class="left"><a href="draft-ietf-httpbis-semantics-latest.html#protocol.version" title="Protocol Versioning">Section 3.5</a> of <a href="#Semantics" id="rfc.xref.Semantics.51"><cite title="HTTP Semantics">[Semantics]</cite></a></td>
                         </tr>
                      </tbody>
                   </table>
@@ -2656,7 +2657,7 @@ Upgrade: HTTP/2.0
          <div id="rfc.section.11.p.1">
             <p>This section is meant to inform developers, information providers, and users of known
                security considerations relevant to HTTP message syntax, parsing, and routing. Security
-               considerations about HTTP semantics and payloads are addressed in <a href="#Semantics" id="rfc.xref.Semantics.55"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.11.p.1">¶</a></p>
+               considerations about HTTP semantics and payloads are addressed in <a href="#Semantics" id="rfc.xref.Semantics.52"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.11.p.1">¶</a></p>
          </div>
          <section id="response.splitting">
             <h3 id="rfc.section.11.1"><a href="#rfc.section.11.1">11.1.</a>&nbsp;<a href="#response.splitting">Response Splitting</a></h3>
@@ -2745,7 +2746,7 @@ Upgrade: HTTP/2.0
             </div>
             <div id="rfc.section.11.4.p.2">
                <p>The "https" scheme can be used to identify resources that require a confidential connection,
-                  as described in <a href="draft-ietf-httpbis-semantics-latest.html#https.uri" title="https URI Scheme">Section 2.5.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.56"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.11.4.p.2">¶</a></p>
+                  as described in <a href="draft-ietf-httpbis-semantics-latest.html#https.uri" title="https URI Scheme">Section 2.5.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.53"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.11.4.p.2">¶</a></p>
             </div>
          </section>
       </section>
@@ -2879,9 +2880,9 @@ Upgrade: HTTP/2.0
       <section id="collected.abnf">
          <h2 id="rfc.section.A" class="np"><a href="#rfc.section.A">A.</a>&nbsp;<a href="#collected.abnf">Collected ABNF</a></h2>
          <div id="rfc.section.A.p.1">
-            <p>In the collected ABNF below, list rules are expanded as per <a href="draft-ietf-httpbis-semantics-latest.html#abnf.extension" title="ABNF List Extension: #rule">Section 11</a> of <a href="#Semantics" id="rfc.xref.Semantics.57"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.A.p.1">¶</a></p>
+            <p>In the collected ABNF below, list rules are expanded as per <a href="draft-ietf-httpbis-semantics-latest.html#abnf.extension" title="ABNF List Extension: #rule">Section 11</a> of <a href="#Semantics" id="rfc.xref.Semantics.54"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.A.p.1">¶</a></p>
          </div>
-         <div id="rfc.section.A.p.2"><pre class="inline prettyprint lang-ietf_abnf"><a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> = &lt;BWS, see <a href="#Semantics" id="rfc.xref.Semantics.58"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
+         <div id="rfc.section.A.p.2"><pre class="inline prettyprint lang-ietf_abnf"><a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">BWS</a> = &lt;BWS, see <a href="#Semantics" id="rfc.xref.Semantics.55"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
 
 <a href="#header.connection" class="smpl">Connection</a> = *( "," OWS ) connection-option *( OWS "," [ OWS
  connection-option ] )
@@ -2891,9 +2892,9 @@ Upgrade: HTTP/2.0
 <a href="#http.version" class="smpl">HTTP-name</a> = %x48.54.54.50 ; HTTP
 <a href="#http.version" class="smpl">HTTP-version</a> = HTTP-name "/" DIGIT "." DIGIT
 
-<a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> = &lt;OWS, see <a href="#Semantics" id="rfc.xref.Semantics.59"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
+<a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">OWS</a> = &lt;OWS, see <a href="#Semantics" id="rfc.xref.Semantics.56"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
 
-<a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">RWS</a> = &lt;RWS, see <a href="#Semantics" id="rfc.xref.Semantics.60"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
+<a href="draft-ietf-httpbis-semantics-latest.html#whitespace" class="smpl">RWS</a> = &lt;RWS, see <a href="#Semantics" id="rfc.xref.Semantics.57"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.3">Section 4.3</a>&gt;
 
 <a href="#header.te" class="smpl">TE</a> = [ ( "," / t-codings ) *( OWS "," [ OWS t-codings ] ) ]
 <a href="#header.transfer-encoding" class="smpl">Transfer-Encoding</a> = *( "," OWS ) transfer-coding *( OWS "," [ OWS
@@ -2903,7 +2904,7 @@ Upgrade: HTTP/2.0
 
 <a href="#imported.rules" class="smpl">absolute-URI</a> = &lt;absolute-URI, see <a href="#RFC3986" id="rfc.xref.RFC3986.6"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-4.3">Section 4.3</a>&gt;
 <a href="#absolute-form" class="smpl">absolute-form</a> = absolute-URI
-<a href="#imported.rules" class="smpl">absolute-path</a> = &lt;absolute-path, see <a href="#Semantics" id="rfc.xref.Semantics.61"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.2.4">Section 2.4</a>&gt;
+<a href="#imported.rules" class="smpl">absolute-path</a> = &lt;absolute-path, see <a href="#Semantics" id="rfc.xref.Semantics.58"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.2.4">Section 2.4</a>&gt;
 <a href="#asterisk-form" class="smpl">asterisk-form</a> = "*"
 <a href="#imported.rules" class="smpl">authority</a> = &lt;authority, see <a href="#RFC3986" id="rfc.xref.RFC3986.7"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.2">Section 3.2</a>&gt;
 <a href="#authority-form" class="smpl">authority-form</a> = authority
@@ -2916,11 +2917,11 @@ Upgrade: HTTP/2.0
 <a href="#chunked.extension" class="smpl">chunk-ext-val</a> = token / quoted-string
 <a href="#chunked.encoding" class="smpl">chunk-size</a> = 1*HEXDIG
 <a href="#chunked.encoding" class="smpl">chunked-body</a> = *chunk last-chunk trailer-part CRLF
-<a href="#imported.rules" class="smpl">comment</a> = &lt;comment, see <a href="#Semantics" id="rfc.xref.Semantics.62"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
+<a href="#imported.rules" class="smpl">comment</a> = &lt;comment, see <a href="#Semantics" id="rfc.xref.Semantics.59"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
 <a href="#header.connection" class="smpl">connection-option</a> = token
 
-<a href="#imported.rules" class="smpl">field-name</a> = &lt;field-name, see <a href="#Semantics" id="rfc.xref.Semantics.63"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2">Section 4.2</a>&gt;
-<a href="#imported.rules" class="smpl">field-value</a> = &lt;field-value, see <a href="#Semantics" id="rfc.xref.Semantics.64"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2">Section 4.2</a>&gt;
+<a href="#imported.rules" class="smpl">field-name</a> = &lt;field-name, see <a href="#Semantics" id="rfc.xref.Semantics.60"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2">Section 4.2</a>&gt;
+<a href="#imported.rules" class="smpl">field-value</a> = &lt;field-value, see <a href="#Semantics" id="rfc.xref.Semantics.61"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2">Section 4.2</a>&gt;
 
 <a href="#header.fields" class="smpl">header-field</a> = field-name ":" OWS field-value OWS
 
@@ -2930,7 +2931,7 @@ Upgrade: HTTP/2.0
 <a href="#request.method" class="smpl">method</a> = token
 
 <a href="#line.folding" class="smpl">obs-fold</a> = CRLF 1*( SP / HTAB )
-<a href="#imported.rules" class="smpl">obs-text</a> = &lt;obs-text, see <a href="#Semantics" id="rfc.xref.Semantics.65"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
+<a href="#imported.rules" class="smpl">obs-text</a> = &lt;obs-text, see <a href="#Semantics" id="rfc.xref.Semantics.62"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
 <a href="#origin-form" class="smpl">origin-form</a> = absolute-path [ "?" query ]
 
 <a href="draft-ietf-httpbis-semantics-latest.html#uri" class="smpl">port</a> = &lt;port, see <a href="#RFC3986" id="rfc.xref.RFC3986.8"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.2.3">Section 3.2.3</a>&gt;
@@ -2939,7 +2940,7 @@ Upgrade: HTTP/2.0
 <a href="#header.upgrade" class="smpl">protocol-version</a> = token
 
 <a href="#imported.rules" class="smpl">query</a> = &lt;query, see <a href="#RFC3986" id="rfc.xref.RFC3986.9"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.4">Section 3.4</a>&gt;
-<a href="#imported.rules" class="smpl">quoted-string</a> = &lt;quoted-string, see <a href="#Semantics" id="rfc.xref.Semantics.66"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
+<a href="#imported.rules" class="smpl">quoted-string</a> = &lt;quoted-string, see <a href="#Semantics" id="rfc.xref.Semantics.63"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
 
 <a href="#header.te" class="smpl">rank</a> = ( "0" [ "." *3DIGIT ] ) / ( "1" [ "." *3"0" ] )
 <a href="#status.line" class="smpl">reason-phrase</a> = *( HTAB / SP / VCHAR / obs-text )
@@ -2953,11 +2954,9 @@ Upgrade: HTTP/2.0
 
 <a href="#header.te" class="smpl">t-codings</a> = "trailers" / ( transfer-coding [ t-ranking ] )
 <a href="#header.te" class="smpl">t-ranking</a> = OWS ";" OWS "q=" rank
-<a href="#imported.rules" class="smpl">token</a> = &lt;token, see <a href="#Semantics" id="rfc.xref.Semantics.67"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
+<a href="#imported.rules" class="smpl">token</a> = &lt;token, see <a href="#Semantics" id="rfc.xref.Semantics.64"><cite title="HTTP Semantics">[Semantics]</cite></a>, <a href="draft-ietf-httpbis-semantics-latest.html#rfc.section.4.2.3">Section 4.2.3</a>&gt;
 <a href="#chunked.trailer.part" class="smpl">trailer-part</a> = *( header-field CRLF )
-<a href="#transfer.codings" class="smpl">transfer-coding</a> = "chunked" / "compress" / "deflate" / "gzip" /
- transfer-extension
-<a href="#transfer.codings" class="smpl">transfer-extension</a> = token *( OWS ";" OWS transfer-parameter )
+<a href="#transfer.codings" class="smpl">transfer-coding</a> = token *( OWS ";" OWS transfer-parameter )
 <a href="#rule.parameter" class="smpl">transfer-parameter</a> = token BWS "=" BWS ( token / quoted-string )
 
 <a href="draft-ietf-httpbis-semantics-latest.html#uri" class="smpl">uri-host</a> = &lt;host, see <a href="#RFC3986" id="rfc.xref.RFC3986.10"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">Section 3.2.2</a>&gt;
@@ -2993,7 +2992,7 @@ Upgrade: HTTP/2.0
             <h3 id="rfc.section.B.2"><a href="#rfc.section.B.2">B.2.</a>&nbsp;<a href="#conversion.to.canonical.form">Conversion to Canonical Form</a></h3>
             <div id="rfc.section.B.2.p.1">
                <p>MIME requires that an Internet mail body part be converted to canonical form prior
-                  to being transferred, as described in <a href="https://tools.ietf.org/html/rfc2049#section-4">Section 4</a> of <a href="#RFC2049" id="rfc.xref.RFC2049.1"><cite title="Multipurpose Internet Mail Extensions (MIME) Part Five: Conformance Criteria and Examples">[RFC2049]</cite></a>. <a href="draft-ietf-httpbis-semantics-latest.html#canonicalization.and.text.defaults" title="Canonicalization and Text Defaults">Section 6.1.1.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.68"><cite title="HTTP Semantics">[Semantics]</cite></a> describes the forms allowed for subtypes of the "text" media type when transmitted
+                  to being transferred, as described in <a href="https://tools.ietf.org/html/rfc2049#section-4">Section 4</a> of <a href="#RFC2049" id="rfc.xref.RFC2049.1"><cite title="Multipurpose Internet Mail Extensions (MIME) Part Five: Conformance Criteria and Examples">[RFC2049]</cite></a>. <a href="draft-ietf-httpbis-semantics-latest.html#canonicalization.and.text.defaults" title="Canonicalization and Text Defaults">Section 6.1.1.2</a> of <a href="#Semantics" id="rfc.xref.Semantics.65"><cite title="HTTP Semantics">[Semantics]</cite></a> describes the forms allowed for subtypes of the "text" media type when transmitted
                   over HTTP. <a href="#RFC2046" id="rfc.xref.RFC2046.1"><cite title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">[RFC2046]</cite></a> requires that content with a type of "text" represent line breaks as CRLF and forbids
                   the use of CR or LF outside of line break sequences. HTTP allows CRLF, bare CR, and
                   bare LF to indicate a line break within text content.<a class="self" href="#rfc.section.B.2.p.1">¶</a></p>
@@ -3013,7 +3012,7 @@ Upgrade: HTTP/2.0
          <section id="conversion.of.date.formats">
             <h3 id="rfc.section.B.3"><a href="#rfc.section.B.3">B.3.</a>&nbsp;<a href="#conversion.of.date.formats">Conversion of Date Formats</a></h3>
             <div id="rfc.section.B.3.p.1">
-               <p>HTTP/1.1 uses a restricted set of date formats (<a href="draft-ietf-httpbis-semantics-latest.html#http.date" title="Date/Time Formats">Section 10.1.1.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.69"><cite title="HTTP Semantics">[Semantics]</cite></a>) to simplify the process of date comparison. Proxies and gateways from other protocols
+               <p>HTTP/1.1 uses a restricted set of date formats (<a href="draft-ietf-httpbis-semantics-latest.html#http.date" title="Date/Time Formats">Section 10.1.1.1</a> of <a href="#Semantics" id="rfc.xref.Semantics.66"><cite title="HTTP Semantics">[Semantics]</cite></a>) to simplify the process of date comparison. Proxies and gateways from other protocols
                   ought to ensure that any <a href="draft-ietf-httpbis-semantics-latest.html#header.date" class="smpl">Date</a> header field present in a message conforms to one of the HTTP/1.1 formats and rewrite
                   the date if necessary.<a class="self" href="#rfc.section.B.3.p.1">¶</a></p>
             </div>
@@ -3051,7 +3050,7 @@ Upgrade: HTTP/2.0
                   not have this limitation, HTTP does not fold long lines. MHTML messages being transported
                   by HTTP follow all conventions of MHTML, including line length limitations and folding,
                   canonicalization, etc., since HTTP transfers message-bodies as payload and, aside
-                  from the "multipart/byteranges" type (<a href="draft-ietf-httpbis-semantics-latest.html#multipart.byteranges" title="Media Type multipart/byteranges">Section 6.3.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.70"><cite title="HTTP Semantics">[Semantics]</cite></a>), does not interpret the content or any MIME header lines that might be contained
+                  from the "multipart/byteranges" type (<a href="draft-ietf-httpbis-semantics-latest.html#multipart.byteranges" title="Media Type multipart/byteranges">Section 6.3.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.67"><cite title="HTTP Semantics">[Semantics]</cite></a>), does not interpret the content or any MIME header lines that might be contained
                   therein.<a class="self" href="#rfc.section.B.6.p.1">¶</a></p>
             </div>
          </section>
@@ -3096,7 +3095,7 @@ Upgrade: HTTP/2.0
             <section id="changes.to.simplify.multihomed.web.servers.and.conserve.ip.addresses">
                <h4 id="rfc.section.C.1.1"><a href="#rfc.section.C.1.1">C.1.1.</a>&nbsp;<a href="#changes.to.simplify.multihomed.web.servers.and.conserve.ip.addresses">Multihomed Web Servers</a></h4>
                <div id="rfc.section.C.1.1.p.1">
-                  <p>The requirements that clients and servers support the <a href="draft-ietf-httpbis-semantics-latest.html#header.host" class="smpl">Host</a> header field (<a href="draft-ietf-httpbis-semantics-latest.html#header.host" title="Host">Section 5.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.71"><cite title="HTTP Semantics">[Semantics]</cite></a>), report an error if it is missing from an HTTP/1.1 request, and accept absolute
+                  <p>The requirements that clients and servers support the <a href="draft-ietf-httpbis-semantics-latest.html#header.host" class="smpl">Host</a> header field (<a href="draft-ietf-httpbis-semantics-latest.html#header.host" title="Host">Section 5.4</a> of <a href="#Semantics" id="rfc.xref.Semantics.68"><cite title="HTTP Semantics">[Semantics]</cite></a>), report an error if it is missing from an HTTP/1.1 request, and accept absolute
                      URIs (<a href="#request.target" title="Request Target">Section&nbsp;3.2</a>) are among the most important changes defined by HTTP/1.1.<a class="self" href="#rfc.section.C.1.1.p.1">¶</a></p>
                </div>
                <div id="rfc.section.C.1.1.p.2">
@@ -3155,7 +3154,7 @@ Upgrade: HTTP/2.0
             <div id="rfc.section.C.2.p.1">
                <p>Most of the sections introducing HTTP's design goals, history, architecture, conformance
                   criteria, protocol versioning, URIs, message routing, and header field values have
-                  been moved to <a href="#Semantics" id="rfc.xref.Semantics.72"><cite title="HTTP Semantics">[Semantics]</cite></a>. This document has been reduced to just the messaging syntax and connection management
+                  been moved to <a href="#Semantics" id="rfc.xref.Semantics.69"><cite title="HTTP Semantics">[Semantics]</cite></a>. This document has been reduced to just the messaging syntax and connection management
                   requirements specific to HTTP/1.1.<a class="self" href="#rfc.section.C.2.p.1">¶</a></p>
             </div>
             <div id="rfc.section.C.2.p.2" class="avoidbreakafter">
@@ -3200,11 +3199,11 @@ Upgrade: HTTP/2.0
             <h3 id="rfc.section.D.2"><a href="#rfc.section.D.2">D.2.</a>&nbsp;<a href="#changes.since.00">Since draft-ietf-httpbis-messaging-00</a> <a class="self" href="https://tools.ietf.org/html/draft-ietf-httpbis-messaging-00" title="plain text">📄</a> <a class="self" href="https://tools.ietf.org/rfcdiff?url2=draft-ietf-httpbis-messaging-01" title="diffs">🔍</a></h3>
             <div id="rfc.section.D.2.p.1" class="avoidbreakafter">
                <p>The changes in this draft are editorial, with respect to HTTP as a whole, to move
-                  all core HTTP semantics into <a href="#Semantics" id="rfc.xref.Semantics.73"><cite title="HTTP Semantics">[Semantics]</cite></a>:<a class="self" href="#rfc.section.D.2.p.1">¶</a></p>
+                  all core HTTP semantics into <a href="#Semantics" id="rfc.xref.Semantics.70"><cite title="HTTP Semantics">[Semantics]</cite></a>:<a class="self" href="#rfc.section.D.2.p.1">¶</a></p>
             </div>
             <div id="rfc.section.D.2.p.2">
                <ul>
-                  <li>Moved introduction, architecture, conformance, and ABNF extensions from <a href="#RFC7230" id="rfc.xref.RFC7230.4">RFC 7230 (Messaging)</a> to semantics <a href="#Semantics" id="rfc.xref.Semantics.74"><cite title="HTTP Semantics">[Semantics]</cite></a>.
+                  <li>Moved introduction, architecture, conformance, and ABNF extensions from <a href="#RFC7230" id="rfc.xref.RFC7230.4">RFC 7230 (Messaging)</a> to semantics <a href="#Semantics" id="rfc.xref.Semantics.71"><cite title="HTTP Semantics">[Semantics]</cite></a>.
                   </li>
                   <li>Moved discussion of MIME differences from <a href="#RFC7231" id="rfc.xref.RFC7231.1">RFC 7231 (Semantics)</a> to <a href="#differences.between.http.and.mime" title="Differences between HTTP and MIME">Appendix&nbsp;B</a> since they mostly cover transforming 1.1 messages.
                   </li>
@@ -3255,6 +3254,8 @@ Upgrade: HTTP/2.0
             <h3 id="rfc.section.D.5"><a href="#rfc.section.D.5">D.5.</a>&nbsp;<a href="#changes.since.03">Since draft-ietf-httpbis-messaging-03</a> <a class="self" href="https://tools.ietf.org/html/draft-ietf-httpbis-messaging-03" title="plain text">📄</a></h3>
             <div id="rfc.section.D.5.p.1">
                <ul>
+                  <li>In <a href="#transfer.codings" title="Transfer Codings">Section&nbsp;7</a>, remove the predefined codings from the ABNF and make it generic instead (&lt;<a href="https://github.com/httpwg/http-core/issues/66">https://github.com/httpwg/http-core/issues/66</a>&gt;)
+                  </li>
                   <li>Use RFC 7405 ABNF notation for case-sensitive string constants (&lt;<a href="https://github.com/httpwg/http-core/issues/133">https://github.com/httpwg/http-core/issues/133</a>&gt;)
                   </li>
                </ul>
@@ -3264,7 +3265,7 @@ Upgrade: HTTP/2.0
       <section id="acks">
          <h2 id="rfc.section.unnumbered-1"><a href="#acks">Acknowledgments</a></h2>
          <div id="rfc.section.unnumbered-1.p.1">
-            <p>See <a href="draft-ietf-httpbis-semantics-latest.html#acks" title="Acknowledgments">Appendix "Acknowledgments"</a> of <a href="#Semantics" id="rfc.xref.Semantics.75"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.unnumbered-1.p.1">¶</a></p>
+            <p>See <a href="draft-ietf-httpbis-semantics-latest.html#acks" title="Acknowledgments">Appendix "Acknowledgments"</a> of <a href="#Semantics" id="rfc.xref.Semantics.72"><cite title="HTTP Semantics">[Semantics]</cite></a>.<a class="self" href="#rfc.section.unnumbered-1.p.1">¶</a></p>
          </div>
       </section>
       <section id="rfc.index">
@@ -3311,15 +3312,15 @@ Upgrade: HTTP/2.0
                            <li>ALPHA&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li><span class="tt">asterisk-form</span>&nbsp;&nbsp;<a href="#rfc.iref.g.11">3.2</a>, <a href="#rfc.iref.g.15"><b>3.2.4</b></a></li>
                            <li><span class="tt">authority-form</span>&nbsp;&nbsp;<a href="#rfc.iref.g.10">3.2</a>, <a href="#rfc.iref.g.14"><b>3.2.3</b></a></li>
-                           <li><span class="tt">chunk</span>&nbsp;&nbsp;<a href="#rfc.iref.g.29"><b>7.1</b></a></li>
-                           <li><span class="tt">chunk-data</span>&nbsp;&nbsp;<a href="#rfc.iref.g.34"><b>7.1</b></a></li>
-                           <li><span class="tt">chunk-ext</span>&nbsp;&nbsp;<a href="#rfc.iref.g.33">7.1</a>, <a href="#rfc.iref.g.35"><b>7.1.1</b></a></li>
-                           <li><span class="tt">chunk-ext-name</span>&nbsp;&nbsp;<a href="#rfc.iref.g.36"><b>7.1.1</b></a></li>
-                           <li><span class="tt">chunk-ext-val</span>&nbsp;&nbsp;<a href="#rfc.iref.g.37"><b>7.1.1</b></a></li>
-                           <li><span class="tt">chunk-size</span>&nbsp;&nbsp;<a href="#rfc.iref.g.30"><b>7.1</b></a></li>
-                           <li><span class="tt">chunked-body</span>&nbsp;&nbsp;<a href="#rfc.iref.g.28"><b>7.1</b></a></li>
-                           <li><span class="tt">Connection</span>&nbsp;&nbsp;<a href="#rfc.iref.g.44"><b>9.1</b></a></li>
-                           <li><span class="tt">connection-option</span>&nbsp;&nbsp;<a href="#rfc.iref.g.45"><b>9.1</b></a></li>
+                           <li><span class="tt">chunk</span>&nbsp;&nbsp;<a href="#rfc.iref.g.28"><b>7.1</b></a></li>
+                           <li><span class="tt">chunk-data</span>&nbsp;&nbsp;<a href="#rfc.iref.g.33"><b>7.1</b></a></li>
+                           <li><span class="tt">chunk-ext</span>&nbsp;&nbsp;<a href="#rfc.iref.g.32">7.1</a>, <a href="#rfc.iref.g.34"><b>7.1.1</b></a></li>
+                           <li><span class="tt">chunk-ext-name</span>&nbsp;&nbsp;<a href="#rfc.iref.g.35"><b>7.1.1</b></a></li>
+                           <li><span class="tt">chunk-ext-val</span>&nbsp;&nbsp;<a href="#rfc.iref.g.36"><b>7.1.1</b></a></li>
+                           <li><span class="tt">chunk-size</span>&nbsp;&nbsp;<a href="#rfc.iref.g.29"><b>7.1</b></a></li>
+                           <li><span class="tt">chunked-body</span>&nbsp;&nbsp;<a href="#rfc.iref.g.27"><b>7.1</b></a></li>
+                           <li><span class="tt">Connection</span>&nbsp;&nbsp;<a href="#rfc.iref.g.43"><b>9.1</b></a></li>
+                           <li><span class="tt">connection-option</span>&nbsp;&nbsp;<a href="#rfc.iref.g.44"><b>9.1</b></a></li>
                            <li>CR&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li>CRLF&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li>CTL&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
@@ -3327,20 +3328,20 @@ Upgrade: HTTP/2.0
                            <li>DQUOTE&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li>field-name&nbsp;&nbsp;<a href="#rfc.iref.g.20">5</a></li>
                            <li>field-value&nbsp;&nbsp;<a href="#rfc.iref.g.21">5</a></li>
-                           <li><span class="tt">header-field</span>&nbsp;&nbsp;<a href="#rfc.iref.g.19"><b>5</b></a>, <a href="#rfc.iref.g.39">7.1.2</a></li>
+                           <li><span class="tt">header-field</span>&nbsp;&nbsp;<a href="#rfc.iref.g.19"><b>5</b></a>, <a href="#rfc.iref.g.38">7.1.2</a></li>
                            <li>HEXDIG&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li>HTAB&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li><span class="tt">HTTP-message</span>&nbsp;&nbsp;<a href="#rfc.iref.g.1"><b>2.1</b></a></li>
                            <li><span class="tt">HTTP-name</span>&nbsp;&nbsp;<a href="#rfc.iref.g.4"><b>2.2</b></a></li>
                            <li><span class="tt">HTTP-version</span>&nbsp;&nbsp;<a href="#rfc.iref.g.3"><b>2.2</b></a></li>
-                           <li><span class="tt">last-chunk</span>&nbsp;&nbsp;<a href="#rfc.iref.g.31"><b>7.1</b></a></li>
+                           <li><span class="tt">last-chunk</span>&nbsp;&nbsp;<a href="#rfc.iref.g.30"><b>7.1</b></a></li>
                            <li>LF&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li><span class="tt">message-body</span>&nbsp;&nbsp;<a href="#rfc.iref.g.23"><b>6</b></a></li>
                            <li><span class="tt">method</span>&nbsp;&nbsp;<a href="#rfc.iref.g.6"><b>3.1</b></a></li>
                            <li><span class="tt">obs-fold</span>&nbsp;&nbsp;<a href="#rfc.iref.g.22"><b>5.2</b></a></li>
                            <li>OCTET&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                            <li><span class="tt">origin-form</span>&nbsp;&nbsp;<a href="#rfc.iref.g.8">3.2</a>, <a href="#rfc.iref.g.12"><b>3.2.1</b></a></li>
-                           <li><span class="tt">rank</span>&nbsp;&nbsp;<a href="#rfc.iref.g.43"><b>7.4</b></a></li>
+                           <li><span class="tt">rank</span>&nbsp;&nbsp;<a href="#rfc.iref.g.42"><b>7.4</b></a></li>
                            <li><span class="tt">reason-phrase</span>&nbsp;&nbsp;<a href="#rfc.iref.g.18"><b>4</b></a></li>
                            <li><span class="tt">request-line</span>&nbsp;&nbsp;<a href="#rfc.iref.g.5"><b>3</b></a></li>
                            <li><span class="tt">request-target</span>&nbsp;&nbsp;<a href="#rfc.iref.g.7"><b>3.2</b></a></li>
@@ -3348,15 +3349,14 @@ Upgrade: HTTP/2.0
                            <li><span class="tt">start-line</span>&nbsp;&nbsp;<a href="#rfc.iref.g.2"><b>2.1</b></a></li>
                            <li><span class="tt">status-code</span>&nbsp;&nbsp;<a href="#rfc.iref.g.17"><b>4</b></a></li>
                            <li><span class="tt">status-line</span>&nbsp;&nbsp;<a href="#rfc.iref.g.16"><b>4</b></a></li>
-                           <li><span class="tt">t-codings</span>&nbsp;&nbsp;<a href="#rfc.iref.g.41"><b>7.4</b></a></li>
-                           <li><span class="tt">t-ranking</span>&nbsp;&nbsp;<a href="#rfc.iref.g.42"><b>7.4</b></a></li>
-                           <li><span class="tt">TE</span>&nbsp;&nbsp;<a href="#rfc.iref.g.40"><b>7.4</b></a></li>
-                           <li><span class="tt">trailer-part</span>&nbsp;&nbsp;<a href="#rfc.iref.g.32">7.1</a>, <a href="#rfc.iref.g.38"><b>7.1.2</b></a></li>
+                           <li><span class="tt">t-codings</span>&nbsp;&nbsp;<a href="#rfc.iref.g.40"><b>7.4</b></a></li>
+                           <li><span class="tt">t-ranking</span>&nbsp;&nbsp;<a href="#rfc.iref.g.41"><b>7.4</b></a></li>
+                           <li><span class="tt">TE</span>&nbsp;&nbsp;<a href="#rfc.iref.g.39"><b>7.4</b></a></li>
+                           <li><span class="tt">trailer-part</span>&nbsp;&nbsp;<a href="#rfc.iref.g.31">7.1</a>, <a href="#rfc.iref.g.37"><b>7.1.2</b></a></li>
                            <li><span class="tt">transfer-coding</span>&nbsp;&nbsp;<a href="#rfc.iref.g.25"><b>7</b></a></li>
                            <li><span class="tt">Transfer-Encoding</span>&nbsp;&nbsp;<a href="#rfc.iref.g.24"><b>6.1</b></a></li>
-                           <li><span class="tt">transfer-extension</span>&nbsp;&nbsp;<a href="#rfc.iref.g.26"><b>7</b></a></li>
-                           <li><span class="tt">transfer-parameter</span>&nbsp;&nbsp;<a href="#rfc.iref.g.27"><b>7</b></a></li>
-                           <li><span class="tt">Upgrade</span>&nbsp;&nbsp;<a href="#rfc.iref.g.46"><b>9.8</b></a></li>
+                           <li><span class="tt">transfer-parameter</span>&nbsp;&nbsp;<a href="#rfc.iref.g.26"><b>7</b></a></li>
+                           <li><span class="tt">Upgrade</span>&nbsp;&nbsp;<a href="#rfc.iref.g.45"><b>9.8</b></a></li>
                            <li>VCHAR&nbsp;&nbsp;<a href="#rfc.section.1.2"><b>1.2</b></a></li>
                         </ul>
                      </li>
@@ -3439,53 +3439,53 @@ Upgrade: HTTP/2.0
                   </ul>
                </li>
                <li><a id="rfc.index.S" href="#rfc.index.S"><b>S</b></a><ul>
-                     <li><em>Semantics</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.1">1</a>, <a href="#rfc.xref.Semantics.2">1</a>, <a href="#rfc.xref.Semantics.3">1.1</a>, <a href="#rfc.xref.Semantics.4">1.2</a>, <a href="#rfc.xref.Semantics.5">1.2</a>, <a href="#rfc.xref.Semantics.6">1.2</a>, <a href="#rfc.xref.Semantics.7">1.2</a>, <a href="#rfc.xref.Semantics.8">1.2</a>, <a href="#rfc.xref.Semantics.9">1.2</a>, <a href="#rfc.xref.Semantics.10">1.2</a>, <a href="#rfc.xref.Semantics.11">1.2</a>, <a href="#rfc.xref.Semantics.12">1.2</a>, <a href="#rfc.xref.Semantics.13">1.2</a>, <a href="#rfc.xref.Semantics.14">1.2</a>, <a href="#rfc.xref.Semantics.15">1.2</a>, <a href="#rfc.xref.Semantics.16">2.2</a>, <a href="#rfc.xref.Semantics.17">3</a>, <a href="#rfc.xref.Semantics.18">3</a>, <a href="#rfc.xref.Semantics.19">3.1</a>, <a href="#rfc.xref.Semantics.20">3.2.1</a>, <a href="#rfc.xref.Semantics.21">3.2.2</a>, <a href="#rfc.xref.Semantics.22">3.2.3</a>, <a href="#rfc.xref.Semantics.23">3.2.4</a>, <a href="#rfc.xref.Semantics.24">3.3</a>, <a href="#rfc.xref.Semantics.25">4</a>, <a href="#rfc.xref.Semantics.26">5</a>, <a href="#rfc.xref.Semantics.27">6</a>, <a href="#rfc.xref.Semantics.28">6</a>, <a href="#rfc.xref.Semantics.29">6</a>, <a href="#rfc.xref.Semantics.30">6.1</a>, <a href="#rfc.xref.Semantics.31">6.1</a>, <a href="#rfc.xref.Semantics.32">6.1</a>, <a href="#rfc.xref.Semantics.33">6.2</a>, <a href="#rfc.xref.Semantics.34">7</a>, <a href="#rfc.xref.Semantics.35">7</a>, <a href="#rfc.xref.Semantics.36">7</a>, <a href="#rfc.xref.Semantics.37">7.1.2</a>, <a href="#rfc.xref.Semantics.38">7.1.2</a>, <a href="#rfc.xref.Semantics.39">7.1.2</a>, <a href="#rfc.xref.Semantics.40">7.2</a>, <a href="#rfc.xref.Semantics.41">7.2</a>, <a href="#rfc.xref.Semantics.42">7.2</a>, <a href="#rfc.xref.Semantics.43">7.3</a>, <a href="#rfc.xref.Semantics.44">7.4</a>, <a href="#rfc.xref.Semantics.45">9</a>, <a href="#rfc.xref.Semantics.46">9</a>, <a href="#rfc.xref.Semantics.47">9.3</a>, <a href="#rfc.xref.Semantics.48">9.4.1</a>, <a href="#rfc.xref.Semantics.49">9.4.2</a>, <a href="#rfc.xref.Semantics.50">9.4.2</a>, <a href="#rfc.xref.Semantics.51">9.8</a>, <a href="#rfc.xref.Semantics.52">9.8</a>, <a href="#rfc.xref.Semantics.53">9.8.1</a>, <a href="#rfc.xref.Semantics.54">9.8.1</a>, <a href="#rfc.xref.Semantics.55">11</a>, <a href="#rfc.xref.Semantics.56">11.4</a>, <a href="#Semantics"><b>13.1</b></a>, <a href="#rfc.xref.Semantics.57">A</a>, <a href="#rfc.xref.Semantics.58">A</a>, <a href="#rfc.xref.Semantics.59">A</a>, <a href="#rfc.xref.Semantics.60">A</a>, <a href="#rfc.xref.Semantics.61">A</a>, <a href="#rfc.xref.Semantics.62">A</a>, <a href="#rfc.xref.Semantics.63">A</a>, <a href="#rfc.xref.Semantics.64">A</a>, <a href="#rfc.xref.Semantics.65">A</a>, <a href="#rfc.xref.Semantics.66">A</a>, <a href="#rfc.xref.Semantics.67">A</a>, <a href="#rfc.xref.Semantics.68">B.2</a>, <a href="#rfc.xref.Semantics.69">B.3</a>, <a href="#rfc.xref.Semantics.70">B.6</a>, <a href="#rfc.xref.Semantics.71">C.1.1</a>, <a href="#rfc.xref.Semantics.72">C.2</a>, <a href="#rfc.xref.Semantics.73">D.2</a>, <a href="#rfc.xref.Semantics.74">D.2</a>, <a href="#rfc.xref.Semantics.75">E</a><ul>
-                           <li><em>Section 2.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.61">A</a></li>
-                           <li><em>Section 4.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.63">A</a>, <a href="#rfc.xref.Semantics.64">A</a></li>
-                           <li><em>Section 4.2.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.62">A</a>, <a href="#rfc.xref.Semantics.65">A</a>, <a href="#rfc.xref.Semantics.66">A</a>, <a href="#rfc.xref.Semantics.67">A</a></li>
-                           <li><em>Section 4.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.58">A</a>, <a href="#rfc.xref.Semantics.59">A</a>, <a href="#rfc.xref.Semantics.60">A</a></li>
+                     <li><em>Semantics</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.1">1</a>, <a href="#rfc.xref.Semantics.2">1</a>, <a href="#rfc.xref.Semantics.3">1.1</a>, <a href="#rfc.xref.Semantics.4">1.2</a>, <a href="#rfc.xref.Semantics.5">1.2</a>, <a href="#rfc.xref.Semantics.6">1.2</a>, <a href="#rfc.xref.Semantics.7">1.2</a>, <a href="#rfc.xref.Semantics.8">1.2</a>, <a href="#rfc.xref.Semantics.9">1.2</a>, <a href="#rfc.xref.Semantics.10">1.2</a>, <a href="#rfc.xref.Semantics.11">1.2</a>, <a href="#rfc.xref.Semantics.12">1.2</a>, <a href="#rfc.xref.Semantics.13">1.2</a>, <a href="#rfc.xref.Semantics.14">1.2</a>, <a href="#rfc.xref.Semantics.15">1.2</a>, <a href="#rfc.xref.Semantics.16">2.2</a>, <a href="#rfc.xref.Semantics.17">3</a>, <a href="#rfc.xref.Semantics.18">3</a>, <a href="#rfc.xref.Semantics.19">3.1</a>, <a href="#rfc.xref.Semantics.20">3.2.1</a>, <a href="#rfc.xref.Semantics.21">3.2.2</a>, <a href="#rfc.xref.Semantics.22">3.2.3</a>, <a href="#rfc.xref.Semantics.23">3.2.4</a>, <a href="#rfc.xref.Semantics.24">3.3</a>, <a href="#rfc.xref.Semantics.25">4</a>, <a href="#rfc.xref.Semantics.26">5</a>, <a href="#rfc.xref.Semantics.27">6</a>, <a href="#rfc.xref.Semantics.28">6</a>, <a href="#rfc.xref.Semantics.29">6</a>, <a href="#rfc.xref.Semantics.30">6.1</a>, <a href="#rfc.xref.Semantics.31">6.1</a>, <a href="#rfc.xref.Semantics.32">6.1</a>, <a href="#rfc.xref.Semantics.33">6.2</a>, <a href="#rfc.xref.Semantics.34">7.1.2</a>, <a href="#rfc.xref.Semantics.35">7.1.2</a>, <a href="#rfc.xref.Semantics.36">7.1.2</a>, <a href="#rfc.xref.Semantics.37">7.2</a>, <a href="#rfc.xref.Semantics.38">7.2</a>, <a href="#rfc.xref.Semantics.39">7.2</a>, <a href="#rfc.xref.Semantics.40">7.3</a>, <a href="#rfc.xref.Semantics.41">7.4</a>, <a href="#rfc.xref.Semantics.42">9</a>, <a href="#rfc.xref.Semantics.43">9</a>, <a href="#rfc.xref.Semantics.44">9.3</a>, <a href="#rfc.xref.Semantics.45">9.4.1</a>, <a href="#rfc.xref.Semantics.46">9.4.2</a>, <a href="#rfc.xref.Semantics.47">9.4.2</a>, <a href="#rfc.xref.Semantics.48">9.8</a>, <a href="#rfc.xref.Semantics.49">9.8</a>, <a href="#rfc.xref.Semantics.50">9.8.1</a>, <a href="#rfc.xref.Semantics.51">9.8.1</a>, <a href="#rfc.xref.Semantics.52">11</a>, <a href="#rfc.xref.Semantics.53">11.4</a>, <a href="#Semantics"><b>13.1</b></a>, <a href="#rfc.xref.Semantics.54">A</a>, <a href="#rfc.xref.Semantics.55">A</a>, <a href="#rfc.xref.Semantics.56">A</a>, <a href="#rfc.xref.Semantics.57">A</a>, <a href="#rfc.xref.Semantics.58">A</a>, <a href="#rfc.xref.Semantics.59">A</a>, <a href="#rfc.xref.Semantics.60">A</a>, <a href="#rfc.xref.Semantics.61">A</a>, <a href="#rfc.xref.Semantics.62">A</a>, <a href="#rfc.xref.Semantics.63">A</a>, <a href="#rfc.xref.Semantics.64">A</a>, <a href="#rfc.xref.Semantics.65">B.2</a>, <a href="#rfc.xref.Semantics.66">B.3</a>, <a href="#rfc.xref.Semantics.67">B.6</a>, <a href="#rfc.xref.Semantics.68">C.1.1</a>, <a href="#rfc.xref.Semantics.69">C.2</a>, <a href="#rfc.xref.Semantics.70">D.2</a>, <a href="#rfc.xref.Semantics.71">D.2</a>, <a href="#rfc.xref.Semantics.72">E</a><ul>
+                           <li><em>Section 2.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.58">A</a></li>
+                           <li><em>Section 4.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.60">A</a>, <a href="#rfc.xref.Semantics.61">A</a></li>
+                           <li><em>Section 4.2.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.59">A</a>, <a href="#rfc.xref.Semantics.62">A</a>, <a href="#rfc.xref.Semantics.63">A</a>, <a href="#rfc.xref.Semantics.64">A</a></li>
+                           <li><em>Section 4.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.55">A</a>, <a href="#rfc.xref.Semantics.56">A</a>, <a href="#rfc.xref.Semantics.57">A</a></li>
                         </ul>
                         <ul>
                            <li><em>Section 2.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.9">1.2</a></li>
-                           <li><em>Section 2.5.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.46">9</a></li>
-                           <li><em>Section 2.5.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.56">11.4</a></li>
+                           <li><em>Section 2.5.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.43">9</a></li>
+                           <li><em>Section 2.5.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.53">11.4</a></li>
                            <li><em>Section 3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.3">1.1</a>, <a href="#rfc.xref.Semantics.17">3</a></li>
-                           <li><em>Section 3.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.16">2.2</a>, <a href="#rfc.xref.Semantics.53">9.8.1</a>, <a href="#rfc.xref.Semantics.54">9.8.1</a></li>
+                           <li><em>Section 3.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.16">2.2</a>, <a href="#rfc.xref.Semantics.50">9.8.1</a>, <a href="#rfc.xref.Semantics.51">9.8.1</a></li>
                            <li><em>Section 4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.26">5</a></li>
                            <li><em>Section 4.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.11">1.2</a>, <a href="#rfc.xref.Semantics.12">1.2</a></li>
                            <li><em>Section 4.2.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.10">1.2</a>, <a href="#rfc.xref.Semantics.13">1.2</a>, <a href="#rfc.xref.Semantics.14">1.2</a>, <a href="#rfc.xref.Semantics.15">1.2</a></li>
                            <li><em>Section 4.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.6">1.2</a>, <a href="#rfc.xref.Semantics.7">1.2</a>, <a href="#rfc.xref.Semantics.8">1.2</a></li>
-                           <li><em>Section 5.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.45">9</a></li>
+                           <li><em>Section 5.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.42">9</a></li>
                            <li><em>Section 5.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.24">3.3</a></li>
-                           <li><em>Section 5.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.20">3.2.1</a>, <a href="#rfc.xref.Semantics.71">C.1.1</a></li>
+                           <li><em>Section 5.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.20">3.2.1</a>, <a href="#rfc.xref.Semantics.68">C.1.1</a></li>
                            <li><em>Section 5.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.21">3.2.2</a></li>
-                           <li><em>Section 6.1.1.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.68">B.2</a></li>
-                           <li><em>Section 6.1.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.30">6.1</a>, <a href="#rfc.xref.Semantics.43">7.3</a></li>
-                           <li><em>Section 6.1.2.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.34">7</a>, <a href="#rfc.xref.Semantics.40">7.2</a></li>
-                           <li><em>Section 6.1.2.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.35">7</a>, <a href="#rfc.xref.Semantics.41">7.2</a></li>
-                           <li><em>Section 6.1.2.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.36">7</a>, <a href="#rfc.xref.Semantics.42">7.2</a></li>
+                           <li><em>Section 6.1.1.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.65">B.2</a></li>
+                           <li><em>Section 6.1.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.30">6.1</a>, <a href="#rfc.xref.Semantics.40">7.3</a></li>
+                           <li><em>Section 6.1.2.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.37">7.2</a></li>
+                           <li><em>Section 6.1.2.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.38">7.2</a></li>
+                           <li><em>Section 6.1.2.3</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.39">7.2</a></li>
                            <li><em>Section 6.2.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.33">6.2</a></li>
-                           <li><em>Section 6.3.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.70">B.6</a></li>
+                           <li><em>Section 6.3.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.67">B.6</a></li>
                            <li><em>Section 7</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.19">3.1</a></li>
-                           <li><em>Section 7.2.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.49">9.4.2</a></li>
-                           <li><em>Section 7.2.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.48">9.4.1</a>, <a href="#rfc.xref.Semantics.50">9.4.2</a></li>
+                           <li><em>Section 7.2.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.46">9.4.2</a></li>
+                           <li><em>Section 7.2.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.45">9.4.1</a>, <a href="#rfc.xref.Semantics.47">9.4.2</a></li>
                            <li><em>Section 7.3.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.28">6</a></li>
                            <li><em>Section 7.3.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.27">6</a></li>
                            <li><em>Section 7.3.6</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.22">3.2.3</a>, <a href="#rfc.xref.Semantics.29">6</a>, <a href="#rfc.xref.Semantics.32">6.1</a></li>
                            <li><em>Section 7.3.7</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.23">3.2.4</a></li>
-                           <li><em>Section 8</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.37">7.1.2</a></li>
-                           <li><em>Section 8.1.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.51">9.8</a></li>
-                           <li><em>Section 8.4.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.44">7.4</a></li>
-                           <li><em>Section 8.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.38">7.1.2</a></li>
+                           <li><em>Section 8</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.34">7.1.2</a></li>
+                           <li><em>Section 8.1.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.48">9.8</a></li>
+                           <li><em>Section 8.4.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.41">7.4</a></li>
+                           <li><em>Section 8.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.35">7.1.2</a></li>
                            <li><em>Section 9</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.25">4</a></li>
-                           <li><em>Section 9.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.47">9.3</a></li>
-                           <li><em>Section 9.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.52">9.8</a></li>
+                           <li><em>Section 9.2</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.44">9.3</a></li>
+                           <li><em>Section 9.4</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.49">9.8</a></li>
                            <li><em>Section 9.4.5</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.31">6.1</a></li>
                            <li><em>Section 9.5.15</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.18">3</a></li>
-                           <li><em>Section 10.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.39">7.1.2</a></li>
-                           <li><em>Section 10.1.1.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.69">B.3</a></li>
-                           <li><em>Section 11</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.4">1.2</a>, <a href="#rfc.xref.Semantics.57">A</a></li>
-                           <li><em>Acknowledgments</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.75">E</a></li>
+                           <li><em>Section 10.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.36">7.1.2</a></li>
+                           <li><em>Section 10.1.1.1</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.66">B.3</a></li>
+                           <li><em>Section 11</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.4">1.2</a>, <a href="#rfc.xref.Semantics.54">A</a></li>
+                           <li><em>Acknowledgments</em>&nbsp;&nbsp;<a href="#rfc.xref.Semantics.72">E</a></li>
                         </ul>
                      </li>
                   </ul>

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1197,13 +1197,8 @@ https://www.example.org
    property of the message rather than a property of the representation
    that is being transferred.
 </t>
-<sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="transfer-coding"/><iref primary="true" item="Grammar" subitem="transfer-extension"/>
-  <x:ref>transfer-coding</x:ref>    = "chunked" ; <xref target="chunked.encoding"/>
-                     / "compress" ; <xref target="compress.coding"/>
-                     / "deflate" ; <xref target="deflate.coding"/>
-                     / "gzip" ; <xref target="gzip.coding"/>
-                     / <x:ref>transfer-extension</x:ref>
-  <x:ref>transfer-extension</x:ref> = <x:ref>token</x:ref> *( <x:ref>OWS</x:ref> ";" <x:ref>OWS</x:ref> <x:ref>transfer-parameter</x:ref> )
+<sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="transfer-coding"/>
+  <x:ref>transfer-coding</x:ref> = <x:ref>token</x:ref> *( <x:ref>OWS</x:ref> ";" <x:ref>OWS</x:ref> <x:ref>transfer-parameter</x:ref> )
 </sourcecode>
 <t anchor="rule.parameter">
   <x:anchor-alias value="transfer-parameter"/>
@@ -1306,6 +1301,10 @@ https://www.example.org
 </t>
 <t>
    A recipient &MUST; be able to parse and decode the chunked transfer coding.
+</t>
+<t>
+   The chunked encoding does not define any parameters. Their presence
+   &SHOULD; be treated as an error.
 </t>
 
 <section title="Chunk Extensions" anchor="chunked.extension">
@@ -1436,7 +1435,7 @@ https://www.example.org
    The following transfer coding names for compression are defined by
    the same algorithm as their corresponding content coding:
 </t>
-<dl newline="false">
+<dl newline="true">
   <dt>compress (and x-compress)</dt>
   <dd>See <xref target="compress.coding"/>.</dd>
   <dt>deflate</dt>
@@ -1444,6 +1443,10 @@ https://www.example.org
   <dt>gzip (and x-gzip)</dt>
   <dd>See <xref target="gzip.coding"/>.</dd>
 </dl>
+<t>
+   The compression codings do not define any parameters. Their presence
+   &SHOULD; be treated as an error.
+</t>
 </section>
 
 <section title="Transfer Coding Registry" anchor="transfer.coding.registry">
@@ -3023,9 +3026,7 @@ Upgrade: HTTP/2.0
 <x:ref>t-ranking</x:ref> = OWS ";" OWS "q=" rank
 <x:ref>token</x:ref> = &lt;token, see <xref target="Semantics" x:fmt="," x:sec="4.2.3"/>&gt;
 <x:ref>trailer-part</x:ref> = *( header-field CRLF )
-<x:ref>transfer-coding</x:ref> = "chunked" / "compress" / "deflate" / "gzip" /
- transfer-extension
-<x:ref>transfer-extension</x:ref> = token *( OWS ";" OWS transfer-parameter )
+<x:ref>transfer-coding</x:ref> = token *( OWS ";" OWS transfer-parameter )
 <x:ref>transfer-parameter</x:ref> = token BWS "=" BWS ( token / quoted-string )
 
 <x:ref>uri-host</x:ref> = &lt;host, see <xref target="RFC3986" x:fmt="," x:sec="3.2.2"/>&gt;
@@ -3352,6 +3353,7 @@ Upgrade: HTTP/2.0
 
 <section title="Since draft-ietf-httpbis-messaging-03" anchor="changes.since.03">
 <ul>
+  <li>In <xref target="transfer.codings"/>, remove the predefined codings from the ABNF and make it generic instead (<eref target="https://github.com/httpwg/http-core/issues/66"/>)</li>
   <li>Use RFC 7405 ABNF notation for case-sensitive string constants (<eref target="https://github.com/httpwg/http-core/issues/133"/>)</li>
 </ul>
 </section>

--- a/httpbis.abnf
+++ b/httpbis.abnf
@@ -207,8 +207,7 @@ time-of-day = hour ":" minute ":" second
 token = 1*tchar
 token68 = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
 trailer-part = *( header-field CRLF )
-transfer-coding = "chunked" / "compress" / "deflate" / "gzip" / transfer-extension
-transfer-extension = token *( OWS ";" OWS transfer-parameter )
+transfer-coding = token *( OWS ";" OWS transfer-parameter )
 transfer-parameter = token BWS "=" BWS ( token / quoted-string )
 type = token
 unsatisfied-range = "*/" complete-length


### PR DESCRIPTION
This one is almost trivial. Except:

- previously, the ABNF sort-of ruled out parameters in the ABNF (at least that was the intent)
- this is now done in prose - we need to say though what to do when parameters *are* present - is "SHOULD treat as error" correct?