### PR TITLE
Fix: #224. Use representation instead of entity

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7943,9 +7943,9 @@ Content-Range: bytes */47022
   <x:anchor-alias value="422 (Unprocessable Entity)"/>
 <t>
    The 422 (Unprocessable Entity) status code indicates that the server
-   understands the content type of the request entity (hence a
+   understands the content type of the representation (hence a
    <x:ref>415 (Unsupported Media Type)</x:ref> status code is inappropriate),
-   and the syntax of the request entity is correct but was unable to process
+   and the syntax of the representation is correct but was unable to process
    the contained instructions. For example, this error condition may occur if
    an XML request body contains well-formed (i.e., syntactically correct), but
    semantically erroneous, XML instructions.


### PR DESCRIPTION
## This PR

Fixes 422 definition as HTTP Semantics replaces entity with representation since RFC7231.

## Notes

We could refine this, stating if 422 applies only to resource representation
or may refer to request-target too (eg. query parameters).