### PR TITLE
Explicitly state that "public" allows responses with Authentication to be stored

### DIFF
--- a/draft-ietf-httpbis-cache-latest.html
+++ b/draft-ietf-httpbis-cache-latest.html
@@ -603,7 +603,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
        content: "Internet-Draft";
   }
   @top-right {
-       content: "November 2019";
+       content: "December 2019";
   }
   @top-center {
        content: "HTTP Caching";
@@ -612,7 +612,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
        content: "Fielding, et al.";
   }
   @bottom-center {
-       content: "Expires May 25, 2020";
+       content: "Expires June 5, 2020";
   }
   @bottom-right {
        content: "[Page " counter(page) "]";
@@ -653,7 +653,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
       <meta name="dcterms.creator" content="Fielding, R.">
       <meta name="dcterms.creator" content="Nottingham, M.">
       <meta name="dcterms.creator" content="Reschke, J. F.">
-      <meta name="dcterms.issued" content="2019-11-22">
+      <meta name="dcterms.issued" content="2019-12-03">
       <meta name="dct.replaces" content="urn:ietf:rfc:7234">
       <meta name="dcterms.abstract" content="The Hypertext Transfer Protocol (HTTP) is a stateless application-level protocol for distributed, collaborative, hypertext information systems. This document defines HTTP caches and the associated header fields that control cache behavior or indicate cacheable response messages. This document obsoletes RFC 7234.">
       <meta name="description" content="The Hypertext Transfer Protocol (HTTP) is a stateless application-level protocol for distributed, collaborative, hypertext information systems. This document defines HTTP caches and the associated header fields that control cache behavior or indicate cacheable response messages. This document obsoletes RFC 7234.">
@@ -680,7 +680,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                   <td class="right">Fastly</td>
                </tr>
                <tr>
-                  <td class="left">Expires: May 25, 2020</td>
+                  <td class="left">Expires: June 5, 2020</td>
                   <td class="right">J. Reschke, Editor</td>
                </tr>
                <tr>
@@ -689,7 +689,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                </tr>
                <tr>
                   <td class="left"></td>
-                  <td class="right">November 22, 2019</td>
+                  <td class="right">December 3, 2019</td>
                </tr>
             </tbody>
          </table>
@@ -743,7 +743,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                Internet-Drafts as reference material or to cite them other than as “work in progress”.<a class="self" href="#rfc.boilerplate.1.p.3">¶</a></p>
          </div>
          <div id="rfc.boilerplate.1.p.4">
-            <p>This Internet-Draft will expire on May 25, 2020.<a class="self" href="#rfc.boilerplate.1.p.4">¶</a></p>
+            <p>This Internet-Draft will expire on June 5, 2020.<a class="self" href="#rfc.boilerplate.1.p.4">¶</a></p>
          </div>
       </section>
       <section id="rfc.copyrightnotice">
@@ -2078,6 +2078,10 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                         only within a private cache. (See <a href="#caching.authenticated.responses" title="Storing Responses to Authenticated Requests">Section 3.2</a> for additional details related to the use of public in response to a request containing <a href="draft-ietf-httpbis-semantics-latest.html#header.authorization" class="smpl">Authorization</a>, and <a href="#response.cacheability" title="Storing Responses in Caches">Section 3</a> for details of how public affects responses that would normally not be stored, due
                         to their status codes not being defined as heuristically cacheable; see <a href="#heuristic.freshness" title="Calculating Heuristic Freshness">Section 4.2.2</a>.)<a class="self" href="#rfc.section.5.2.2.5.p.1">¶</a></p>
                   </div>
+                  <div id="rfc.section.5.2.2.5.p.2">
+                     <p>The "public" directive also has the effect of allowing a stored response to be used
+                        to satisfy a request with an Authorization header field; see <a href="#caching.authenticated.responses" title="Storing Responses to Authenticated Requests">Section 3.2</a>.<a class="self" href="#rfc.section.5.2.2.5.p.2">¶</a></p>
+                  </div>
                </section>
                <section id="cache-response-directive.private">
                   <h5 id="rfc.section.5.2.2.6"><a href="#rfc.section.5.2.2.6">5.2.2.6.</a>&nbsp;<a href="#cache-response-directive.private">private</a></h5>
@@ -2155,12 +2159,12 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                   <div id="rfc.section.5.2.2.9.p.3">
                      <p>The "s-maxage" response directive indicates that, in shared caches, the maximum age
                         specified by this directive overrides the maximum age specified by either the max-age
-                        directive or the <a href="#header.expires" class="smpl">Expires</a> header field. The s-maxage directive also implies the semantics of the proxy-revalidate
-                        response directive.<a class="self" href="#rfc.section.5.2.2.9.p.3">¶</a></p>
+                        directive or the <a href="#header.expires" class="smpl">Expires</a> header field.<a class="self" href="#rfc.section.5.2.2.9.p.3">¶</a></p>
                   </div>
                   <div id="rfc.section.5.2.2.9.p.4">
-                     <p>The s-maxage directive also has the effect of allowing a stored response to be used
-                        to satisfy a request with an Authorization header field; see <a href="#caching.authenticated.responses" title="Storing Responses to Authenticated Requests">Section 3.2</a>.<a class="self" href="#rfc.section.5.2.2.9.p.4">¶</a></p>
+                     <p>The "s-maxage" directive also implies the semantics of the "proxy-revalidate" directive.
+                        Consequently, it allows a stored response to be used to satisfy a request with an
+                        Authorization header field; see <a href="#caching.authenticated.responses" title="Storing Responses to Authenticated Requests">Section 3.2</a>.<a class="self" href="#rfc.section.5.2.2.9.p.4">¶</a></p>
                   </div>
                   <div id="rfc.section.5.2.2.9.p.5">
                      <p>This directive uses the token form of the argument syntax: e.g., 's-maxage=10' not
@@ -2424,7 +2428,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                </h3>
                <dl class="reference">
                   <dt id="Messaging">[Messaging]</dt>
-                  <dd>Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., “<a href="draft-ietf-httpbis-messaging-latest.html">HTTP/1.1 Messaging</a>”, Internet-Draft draft-ietf-httpbis-messaging-latest (<a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-messaging">work in progress</a>), November 2019.
+                  <dd>Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., “<a href="draft-ietf-httpbis-messaging-latest.html">HTTP/1.1 Messaging</a>”, Internet-Draft draft-ietf-httpbis-messaging-latest (<a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-messaging">work in progress</a>), December 2019.
                   </dd>
                   <dt id="RFC2119">[RFC2119]</dt>
                   <dd>Bradner, S., “<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>”, BCP 14, RFC 2119, <a href="http://dx.doi.org/10.17487/RFC2119">DOI 10.17487/RFC2119</a>, March 1997, &lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;.
@@ -2439,7 +2443,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                   <dd>Kyzivat, P., “<a href="https://tools.ietf.org/html/rfc7405">Case-Sensitive String Support in ABNF</a>”, RFC 7405, <a href="http://dx.doi.org/10.17487/RFC7405">DOI 10.17487/RFC7405</a>, December 2014, &lt;<a href="https://www.rfc-editor.org/info/rfc7405">https://www.rfc-editor.org/info/rfc7405</a>&gt;.
                   </dd>
                   <dt id="Semantics">[Semantics]</dt>
-                  <dd>Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., “<a href="draft-ietf-httpbis-semantics-latest.html">HTTP Semantics</a>”, Internet-Draft draft-ietf-httpbis-semantics-latest (<a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-semantics">work in progress</a>), November 2019.
+                  <dd>Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., “<a href="draft-ietf-httpbis-semantics-latest.html">HTTP Semantics</a>”, Internet-Draft draft-ietf-httpbis-semantics-latest (<a href="https://datatracker.ietf.org/doc/draft-ietf-httpbis-semantics">work in progress</a>), December 2019.
                   </dd>
                   <dt id="USASCII">[USASCII]</dt>
                   <dd>American National Standards Institute, “Coded Character Set -- 7-bit American Standard Code for Information Interchange”, ANSI X3.4, 1986.</dd>

--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -1596,6 +1596,11 @@
    due to their status codes not being defined as heuristically cacheable; see
    <xref target="heuristic.freshness"/>.)
 </t>
+<t>
+   The "public" directive also has the effect of allowing a stored
+   response to be used to satisfy a request with an Authorization header
+   field; see <xref target="caching.authenticated.responses"/>.
+</t>
 </section>
 
 <section title="private" anchor="cache-response-directive.private">
@@ -1679,11 +1684,11 @@
    The "s-maxage" response directive indicates that, in shared caches, the
    maximum age specified by this directive overrides the maximum age
    specified by either the max-age directive or the <x:ref>Expires</x:ref>
-   header field. The s-maxage directive also implies the semantics of the
-   proxy-revalidate response directive.
+   header field.
 </t>
 <t>
-   The s-maxage directive also has the effect of allowing a stored
+   The "s-maxage" directive also implies the semantics of the
+   "proxy-revalidate" directive. Consequently, it allows a stored
    response to be used to satisfy a request with an Authorization header
    field; see <xref target="caching.authenticated.responses"/>.
 </t>


### PR DESCRIPTION
In #161, the suggestion was made to explicitly note when a directive allows the response to be cached, even with Authorization being used.

According to section `caching.authenticated.responses`, `public` also has this effect, so I added a note there.

Additionally, in `cache-response-directive.s-maxage`, I tried to make it clearer that `s-maxage` overrides Authorization as well, due to the implication of proxy-revalidate and thus must-revalidate.