### PR TITLE
Issue #278, Deprecation of too much userinfo

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -848,22 +848,18 @@ Content-Type: text/plain
 </artwork>
 </section>
 
-<section title="Deprecated userinfo" anchor="http.userinfo">
+<section title="Deprecated Passwords in userinfo" anchor="http.userinfo">
 <t>
-   The URI generic syntax for authority also includes a deprecated
-   userinfo subcomponent (<xref target="RFC3986" x:fmt="," x:sec="3.2.1"/>)
-   for including user authentication information in the URI.  Some
-   implementations make use of the userinfo component for internal
-   configuration of authentication information, such as within command
-   invocation options, configuration files, or bookmark lists, even
-   though such usage might expose a user identifier or password.
-   A sender &MUST-NOT; generate the userinfo subcomponent (and its "@"
-   delimiter) when an "http" URI reference is generated within a message as a
-   request target or header field value.
-   Before making use of an "http" URI reference received from an untrusted
-   source, a recipient &SHOULD; parse for userinfo and treat its presence as
-   an error; it is likely being used to obscure the authority for the sake of
-   phishing attacks.
+   The URI generic syntax for authority also includes a
+   userinfo subcomponent in which the format "user:password" is deprecated
+   <xref target="RFC3986" x:fmt="," x:sec="3.2.1"/>().
+   The user is not deprecated, but the password is.  A sender &MUST-NOT;
+   generate a colon in a userinfo subcomponent when an
+   "http" URI reference is generated within a message as a request
+   target or header field value, but it may prefix a user and an "@" delimiter
+   before the host name in an "http" URI.  Before making use of an "http" URI
+   reference received from an untrusted source, a recipient &SHOULD; parse
+   for userinfo and treat the presence of a colon in it as an error.
 </t>
 </section>
 


### PR DESCRIPTION
Keep user name, specifically drop "user:password"
(I have also removed some explanatory notes do not seem helpful anymore.)