### PR TITLE
Be more correct about what was deprecated by RFC 3986 (and also talk about https URIs) (#278)

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.html
+++ b/draft-ietf-httpbis-semantics-latest.html
@@ -1655,14 +1655,23 @@ Content-Type: text/plain
             <section id="http.userinfo">
                <h4 id="rfc.section.2.5.4"><a href="#rfc.section.2.5.4">2.5.4.</a>&nbsp;<a href="#http.userinfo">Deprecated userinfo</a></h4>
                <div id="rfc.section.2.5.4.p.1">
-                  <p>The URI generic syntax for authority also includes a deprecated userinfo subcomponent
-                     (<a href="#RFC3986" id="rfc.xref.RFC3986.17"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.2.1">Section 3.2.1</a>) for including user authentication information in the URI. Some implementations make
-                     use of the userinfo component for internal configuration of authentication information,
-                     such as within command invocation options, configuration files, or bookmark lists,
-                     even though such usage might expose a user identifier or password. A sender <em class="bcp14">MUST NOT</em> generate the userinfo subcomponent (and its "@" delimiter) when an "http" URI reference
-                     is generated within a message as a request target or header field value. Before making
-                     use of an "http" URI reference received from an untrusted source, a recipient <em class="bcp14">SHOULD</em> parse for userinfo and treat its presence as an error; it is likely being used to
-                     obscure the authority for the sake of phishing attacks.<a class="self" href="#rfc.section.2.5.4.p.1">¶</a></p>
+                  <p>The URI generic syntax for authority also includes a userinfo subcomponent (<a href="#RFC3986" id="rfc.xref.RFC3986.17"><cite title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</cite></a>, <a href="https://tools.ietf.org/html/rfc3986#section-3.2.1">Section 3.2.1</a>) for including user authentication information in the URI. In that subcomponent,
+                     the use of the format "user:password" is deprecated.<a class="self" href="#rfc.section.2.5.4.p.1">¶</a></p>
+               </div>
+               <div id="rfc.section.2.5.4.p.2">
+                  <p>Some implementations make use of the userinfo component for internal configuration
+                     of authentication information, such as within command invocation options, configuration
+                     files, or bookmark lists, even though such usage might expose a user identifier or
+                     password.<a class="self" href="#rfc.section.2.5.4.p.2">¶</a></p>
+               </div>
+               <div id="rfc.section.2.5.4.p.3">
+                  <p>A sender <em class="bcp14">MUST NOT</em> generate the userinfo subcomponent (and its "@" delimiter) when an "http" or "https"
+                     URI reference is generated within a message as a request target or header field value.<a class="self" href="#rfc.section.2.5.4.p.3">¶</a></p>
+               </div>
+               <div id="rfc.section.2.5.4.p.4">
+                  <p>Before making use of an "http" or "https" URI reference received from an untrusted
+                     source, a recipient <em class="bcp14">SHOULD</em> parse for userinfo and treat its presence as an error; it is likely being used to
+                     obscure the authority for the sake of phishing attacks.<a class="self" href="#rfc.section.2.5.4.p.4">¶</a></p>
                </div>
             </section>
             <section id="uri.fragment.identifiers">
@@ -10268,7 +10277,10 @@ Content-Encoding: gzip
          <section id="changes.since.06">
             <h3 id="rfc.section.J.8"><a href="#rfc.section.J.8">J.8.</a>&nbsp;<a href="#changes.since.06">Since draft-ietf-httpbis-semantics-06</a> <a class="self" href="https://tools.ietf.org/html/draft-ietf-httpbis-semantics-06" title="plain text">📄</a></h3>
             <div id="rfc.section.J.8.p.1">
-               <p>None yet.</p>
+               <ul>
+                  <li>In <a href="#http.userinfo" title="Deprecated userinfo">Section 2.5.4</a>, be more correct about what was deprecated by RFC 3986 (&lt;<a href="https://github.com/httpwg/http-core/issues/278">https://github.com/httpwg/http-core/issues/278</a>&gt;, &lt;<a href="https://www.rfc-editor.org/errata/eid5964">https://www.rfc-editor.org/errata/eid5964</a>&gt;)
+                  </li>
+               </ul>
             </div>
          </section>
       </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -850,17 +850,24 @@ Content-Type: text/plain
 
 <section title="Deprecated userinfo" anchor="http.userinfo">
 <t>
-   The URI generic syntax for authority also includes a deprecated
-   userinfo subcomponent (<xref target="RFC3986" x:fmt="," x:sec="3.2.1"/>)
-   for including user authentication information in the URI.  Some
-   implementations make use of the userinfo component for internal
+   The URI generic syntax for authority also includes a userinfo subcomponent
+   (<xref target="RFC3986" x:fmt="," x:sec="3.2.1"/>) for including user
+   authentication information in the URI. In that subcomponent, the
+   use of the format "user:password" is deprecated.
+</t>
+<t>
+   Some implementations make use of the userinfo component for internal
    configuration of authentication information, such as within command
    invocation options, configuration files, or bookmark lists, even
    though such usage might expose a user identifier or password.
+</t>
+<t>
    A sender &MUST-NOT; generate the userinfo subcomponent (and its "@"
-   delimiter) when an "http" URI reference is generated within a message as a
-   request target or header field value.
-   Before making use of an "http" URI reference received from an untrusted
+   delimiter) when an "http" or "https" URI reference is generated within a
+   message as a request target or header field value.
+</t>
+<t>
+   Before making use of an "http" or "https" URI reference received from an untrusted
    source, a recipient &SHOULD; parse for userinfo and treat its presence as
    an error; it is likely being used to obscure the authority for the sake of
    phishing attacks.
@@ -12009,6 +12016,7 @@ Content-Encoding: gzip
 
 <section title="Since draft-ietf-httpbis-semantics-06" anchor="changes.since.06">
 <ul x:when-empty="None yet.">
+  <li>In <xref target="http.userinfo"/>, be more correct about what was deprecated by RFC 3986 (<eref target="https://github.com/httpwg/http-core/issues/278"/>, <eref target="https://www.rfc-editor.org/errata/eid5964"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
(also adds two paragraph breaks)