### PR TITLE
A last fine point towards RFC 3986 correct text

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -890,7 +890,7 @@ Content-Type: text/plain
 <t>
    The URI generic syntax for authority also includes a userinfo subcomponent
    (<xref target="RFC3986" x:fmt="," x:sec="3.2.1"/>) for including user
-   authentication information in the URI. In that subcomponent, the
+   authority information in the URI. In that subcomponent, the
    use of the format "user:password" is deprecated.
 </t>
 <t>


### PR DESCRIPTION
A simple PR to address the still-open part of issue https://github.com/httpwg/http-core/pull/281

URIs relay authority information, not authentication.
The next paragraph is different; it mentions a use _as_ authentication.