### PR TITLE
Case insensitivity for extension points

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -11884,6 +11884,10 @@ Content-Encoding: gzip
   from the description of the OPTIONS method.
   (<xref target="OPTIONS"/>)
 </t>
+<t>
+  Defined range units to be compared in a case insensitive fashion.
+  (xref target="range.units"/>)
+</t>
 </section>
 
 <section title="Changes from RFC 7232" anchor="changes.from.rfc.7232">

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1271,7 +1271,7 @@ Content-Type: text/plain
 </sourcecode>
 <t>
    Field names are case-insensitive and ought to be registered within the
-   "HTTP Field Name" registry; see <xref target="field.name.registry"/>.
+   "Hypertext Transfer Protocol (HTTP) Field Name Registry"; see <xref target="field.name.registry"/>.
 </t>
 
 <t>
@@ -1336,7 +1336,7 @@ namespace for HTTP field names.</t>
 target="considerations.for.new.header.fields"/> for considerations to take
 into account when creating a new HTTP field.</t>
 
-<t>The "HTTP Field Name" registry is located at
+<t>The "Hypertext Transfer Protocol (HTTP) Field Name Registry" is located at
 "https://www.iana.org/assignments/http-fields/". Registration requests can
 be made by following the instructions located there or by sending an email to
 the "ietf-http-wg@ietf.org" mailing list.</t>
@@ -2743,7 +2743,7 @@ Host: www.example.org
 </sourcecode>
 <t>
    All content codings are case-insensitive and ought to be registered
-   within the HTTP Content Coding Registry, as defined in <xref target="content.coding.registry"/>
+   within the "HTTP Content Coding Registry", as defined in <xref target="content.coding.registry"/>
 </t>
 <t>
    Content-coding values are used in the
@@ -2934,7 +2934,7 @@ Host: www.example.org
 </sourcecode>
 <t>
    All range unit names are case-insensitive and ought to be registered
-   within the HTTP Range Unit registry, as defined in <xref target="range.unit.registry"/>
+   within the "HTTP Range Unit Registry", as defined in <xref target="range.unit.registry"/>
 </t>
 <t>
    The following range unit names are defined by this document:
@@ -8374,7 +8374,7 @@ Content-Range: bytes */47022
 </t>
 <t>
    Therefore, the 418 status code is reserved in the IANA HTTP Status Code
-   registry. This indicates that the status code cannot be assigned to other
+   Registry. This indicates that the status code cannot be assigned to other
    applications currently. If future circumstances require its use (e.g.,
    exhaustion of 4NN status codes), it can be re-assigned to another use.
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2742,6 +2742,10 @@ Host: www.example.org
   <x:ref>content-coding</x:ref>   = <x:ref>token</x:ref>
 </sourcecode>
 <t>
+   All content codings are case-insensitive and ought to be registered
+   within the HTTP Content Coding Registry, as defined in <xref target="content.coding.registry"/>
+</t>
+<t>
    Content-coding values are used in the
    <x:ref>Accept-Encoding</x:ref> (<xref target="header.accept-encoding"/>)
    and <x:ref>Content-Encoding</x:ref> (<xref target="header.content-encoding"/>)
@@ -12067,6 +12071,7 @@ Content-Encoding: gzip
   <li>In <xref target="header.field.registration"/>, consider reserved fields as well (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
   <li>In <xref target="http.userinfo"/>, be more correct about what was deprecated by RFC 3986 (<eref target="https://github.com/httpwg/http-core/issues/278"/>, <eref target="https://www.rfc-editor.org/errata/eid5964"/>)</li>
   <li>In <xref target="range.units"/>, explicitly call out range unit names as case-insensitive, and encourage registration (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
+  <li>In <xref target="content.codings"/>, explicitly call out content codings as case-insensitive, and encourage registration (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -11885,7 +11885,7 @@ Content-Encoding: gzip
   (<xref target="OPTIONS"/>)
 </t>
 <t>
-  Specified range units to be compared in a case insensitive fashion.
+  Range units are compared in a case insensitive fashion.
   (xref target="range.units"/>)
 </t>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2929,6 +2929,10 @@ Host: www.example.org
   <x:ref>range-unit</x:ref>       = <x:ref>token</x:ref>
 </sourcecode>
 <t>
+   All range unit names are case-insensitive and ought to be registered
+   within the HTTP Range Unit registry, as defined in <xref target="range.unit.registry"/>
+</t>
+<t>
    The following range unit names are defined by this document:
 </t>
 <table align="left" anchor="iana.range.units.table">
@@ -12062,6 +12066,7 @@ Content-Encoding: gzip
   <li>In <xref target="header.etag"/>, note that Etag can be used in trailers (<eref target="https://github.com/httpwg/http-core/issues/262"/>)</li>
   <li>In <xref target="header.field.registration"/>, consider reserved fields as well (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
   <li>In <xref target="http.userinfo"/>, be more correct about what was deprecated by RFC 3986 (<eref target="https://github.com/httpwg/http-core/issues/278"/>, <eref target="https://www.rfc-editor.org/errata/eid5964"/>)</li>
+  <li>In <xref target="range.units"/>, explicitly call out range unit names as case-insensitive, and encourage registration (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -11885,7 +11885,7 @@ Content-Encoding: gzip
   (<xref target="OPTIONS"/>)
 </t>
 <t>
-  Defined range units to be compared in a case insensitive fashion.
+  Specified range units to be compared in a case insensitive fashion.
   (xref target="range.units"/>)
 </t>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1269,6 +1269,10 @@ Content-Type: text/plain
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="field-name"/>
   <x:ref>field-name</x:ref>     = <x:ref>token</x:ref>
 </sourcecode>
+<t>
+   Field names are case-insensitive and ought to be registered within the
+   "HTTP Field Name" registry; see <xref target="field.name.registry"/>.
+</t>
 
 <t>
    Authors of specifications defining new fields are advised to choose a short
@@ -1320,10 +1324,6 @@ Content-Type: text/plain
    Other recipients &SHOULD; ignore unrecognized header and trailer fields.
    These requirements allow HTTP's functionality to be enhanced without
    requiring prior update of deployed intermediaries.
-</t>
-<t>
-   All defined fields ought to be registered with IANA in the
-   "HTTP Field Name" registry; see <xref target="field.name.registry"/>.
 </t>
 </section>
 
@@ -12072,6 +12072,7 @@ Content-Encoding: gzip
   <li>In <xref target="http.userinfo"/>, be more correct about what was deprecated by RFC 3986 (<eref target="https://github.com/httpwg/http-core/issues/278"/>, <eref target="https://www.rfc-editor.org/errata/eid5964"/>)</li>
   <li>In <xref target="range.units"/>, explicitly call out range unit names as case-insensitive, and encourage registration (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
   <li>In <xref target="content.codings"/>, explicitly call out content codings as case-insensitive, and encourage registration (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
+  <li>In <xref target="field.names"/>, explicitly call out field names as case-insensitive (<eref target="https://github.com/httpwg/http-core/issues/179"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2834,13 +2834,6 @@ Host: www.example.org
 </t>
 </section>
 
-<section title="Content Coding Extensibility" anchor="content.coding.extensibility">
-<t>
-   Additional content codings, outside the scope of this specification, have
-   been specified for use in HTTP. All such content codings ought to be
-   registered within the "HTTP Content Coding Registry".
-</t>
-
 <section title="Content Coding Registry" anchor="content.coding.registry">
 <t>
    The "HTTP Content Coding Registry", maintained by


### PR DESCRIPTION
- Explicitly nominate range units as case insensitive
- Normalise how we talk about case sensitivity of extension points:
  - right next to the ABNF
  - combine with statement encouraging registration


Fixes #179.
