### PR TITLE
The scope of 503 may go beyond the request. See #99.

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -8492,6 +8492,8 @@ Content-Type: text/plain
    The <x:dfn>503 (Service Unavailable)</x:dfn> status code indicates that the
    server is currently unable to handle the request due to a temporary overload
    or scheduled maintenance, which will likely be alleviated after some delay.
+   The above condition might apply to the issued request, to the resource
+   or to the entire server.
    The server &MAY; send a <x:ref>Retry-After</x:ref> header field
    (<xref target="header.retry-after"/>) to suggest an appropriate
    amount of time for the client to wait before retrying the request.


### PR DESCRIPTION
## This PR

Clarifies that 503 may apply not only to the given request.
This is because `Retry-After` states:

> Retry-After indicates
>   how long the service is expected to be unavailable to the client.

Instead 503 states:

> Retry-After [suggests an]
> amount of time for the client to wait before retrying the request.

See: #99 