### PR TITLE
Suggest scoping retry-after using other message parts.

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -8953,7 +8953,6 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    applies to the target resource, to a specific path or to the whole server
    it MAY convey the scope of Retry-After in the payload body
    or in other message parts.
-
 </t>
 <t>
    The value of this field can be either an HTTP-date or a number

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -8946,11 +8946,14 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    agent ought to wait before making a follow-up request. When sent with a
    <x:ref>503 (Service Unavailable)</x:ref> response, Retry-After indicates
    how long the service is expected to be unavailable to the client.
-   The server MAY convey the scope of Retry-After in the payload body
-   or in other message parts.
    When sent with any <x:ref>3xx (Redirection)</x:ref> response, Retry-After
    indicates the minimum time that the user agent is asked to wait before
    issuing the redirected request.
+   In general, if the server wants to detail whether Retry-After
+   applies to the target resource, to a specific path or to the whole server
+   it MAY convey the scope of Retry-After in the payload body
+   or in other message parts.
+
 </t>
 <t>
    The value of this field can be either an HTTP-date or a number

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -8946,6 +8946,8 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    agent ought to wait before making a follow-up request. When sent with a
    <x:ref>503 (Service Unavailable)</x:ref> response, Retry-After indicates
    how long the service is expected to be unavailable to the client.
+   The server MAY convey the scope of Retry-After in the payload body
+   or in other message parts.
    When sent with any <x:ref>3xx (Redirection)</x:ref> response, Retry-After
    indicates the minimum time that the user agent is asked to wait before
    issuing the redirected request.


### PR DESCRIPTION
## This PR

Suggests passing the scope of Retry-After using other message parts.
This includes the payload body or other to-be-defined headers or parameters.

Fixes: #99 