### PR TITLE
add cross references to clarify that Range works on representation data

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.html
+++ b/draft-ietf-httpbis-semantics-latest.html
@@ -10520,6 +10520,12 @@ Content-Encoding: gzip
                   </li>
                   <li>In <a href="#intro.requirements" title="Requirements Notation">Section 1.1</a>, reference RFC 8174 as well (&lt;<a href="https://github.com/httpwg/http-core/issues/303">https://github.com/httpwg/http-core/issues/303</a>&gt;)
                   </li>
+                  <li>In <a href="#header.range" id="rfc.xref.header.range.6" title="Range">Section 8.3</a>, explicitly reference the definition of representation data as including any content
+                     codings (&lt;<a href="https://github.com/httpwg/http-core/issues/11">https://github.com/httpwg/http-core/issues/11</a>&gt;)
+                  </li>
+                  <li>In <a href="#representations" title="Representations">Section 6</a>, explicitly reference 206 as one of the status codes that provide representation
+                     data
+                  </li>
                </ul>
             </div>
          </section>
@@ -10736,7 +10742,7 @@ Content-Encoding: gzip
                            <li>Proxy-Authenticate&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authenticate.1">4.8</a>, <a href="#rfc.xref.header.proxy-authenticate.2">9.5.8</a>, <a href="#rfc.xref.header.proxy-authenticate.3">10.3</a>, <a href="#rfc.section.10.3.2"><b>10.3.2</b></a></li>
                            <li>Proxy-Authentication-Info&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authentication-info.1">4.8</a>, <a href="#rfc.xref.header.proxy-authentication-info.2">10.3</a>, <a href="#rfc.section.10.3.4"><b>10.3.4</b></a></li>
                            <li>Proxy-Authorization&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authorization.1">4.8</a>, <a href="#rfc.xref.header.proxy-authorization.2">8.5</a>, <a href="#rfc.section.8.5.4"><b>8.5.4</b></a>, <a href="#rfc.xref.header.proxy-authorization.3">9.5.8</a>, <a href="#rfc.xref.header.proxy-authorization.4">10.3.4</a></li>
-                           <li>Range&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a></li>
+                           <li>Range&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a>, <a href="#rfc.xref.header.range.6">C.8</a></li>
                            <li>Referer&nbsp;&nbsp;<a href="#rfc.xref.header.referer.1">4.8</a>, <a href="#rfc.xref.header.referer.2">8.6</a>, <a href="#rfc.section.8.6.2"><b>8.6.2</b></a>, <a href="#rfc.xref.header.referer.3">11.8</a></li>
                            <li>Retry-After&nbsp;&nbsp;<a href="#rfc.xref.header.retry-after.1">4.8</a>, <a href="#rfc.xref.header.retry-after.2">9.6.4</a>, <a href="#rfc.xref.header.retry-after.3">10.1</a>, <a href="#rfc.section.10.1.3"><b>10.1.3</b></a></li>
                            <li>Server&nbsp;&nbsp;<a href="#rfc.xref.header.server.1">4.8</a>, <a href="#rfc.xref.header.server.2">10.4</a>, <a href="#rfc.section.10.4.3"><b>10.4.3</b></a>, <a href="#rfc.xref.header.server.3">11.10</a></li>
@@ -10940,7 +10946,7 @@ Content-Encoding: gzip
                            <li>Proxy-Authenticate&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authenticate.1">4.8</a>, <a href="#rfc.xref.header.proxy-authenticate.2">9.5.8</a>, <a href="#rfc.xref.header.proxy-authenticate.3">10.3</a>, <a href="#rfc.section.10.3.2"><b>10.3.2</b></a></li>
                            <li>Proxy-Authentication-Info&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authentication-info.1">4.8</a>, <a href="#rfc.xref.header.proxy-authentication-info.2">10.3</a>, <a href="#rfc.section.10.3.4"><b>10.3.4</b></a></li>
                            <li>Proxy-Authorization&nbsp;&nbsp;<a href="#rfc.xref.header.proxy-authorization.1">4.8</a>, <a href="#rfc.xref.header.proxy-authorization.2">8.5</a>, <a href="#rfc.section.8.5.4"><b>8.5.4</b></a>, <a href="#rfc.xref.header.proxy-authorization.3">9.5.8</a>, <a href="#rfc.xref.header.proxy-authorization.4">10.3.4</a></li>
-                           <li>Range&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a></li>
+                           <li>Range&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a>, <a href="#rfc.xref.header.range.6">C.8</a></li>
                            <li>Referer&nbsp;&nbsp;<a href="#rfc.xref.header.referer.1">4.8</a>, <a href="#rfc.xref.header.referer.2">8.6</a>, <a href="#rfc.section.8.6.2"><b>8.6.2</b></a>, <a href="#rfc.xref.header.referer.3">11.8</a></li>
                            <li>Retry-After&nbsp;&nbsp;<a href="#rfc.xref.header.retry-after.1">4.8</a>, <a href="#rfc.xref.header.retry-after.2">9.6.4</a>, <a href="#rfc.xref.header.retry-after.3">10.1</a>, <a href="#rfc.section.10.1.3"><b>10.1.3</b></a></li>
                            <li>Server&nbsp;&nbsp;<a href="#rfc.xref.header.server.1">4.8</a>, <a href="#rfc.xref.header.server.2">10.4</a>, <a href="#rfc.section.10.4.3"><b>10.4.3</b></a>, <a href="#rfc.xref.header.server.3">11.10</a></li>
@@ -11045,7 +11051,7 @@ Content-Encoding: gzip
                   </ul>
                </li>
                <li><a id="rfc.index.R" href="#rfc.index.R"><b>R</b></a><ul>
-                     <li>Range header field&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a></li>
+                     <li>Range header field&nbsp;&nbsp;<a href="#rfc.xref.header.range.1">4.8</a>, <a href="#rfc.xref.header.range.2">6.1.4</a>, <a href="#rfc.xref.header.range.3">7.3.1</a>, <a href="#rfc.xref.header.range.4">7.4.2</a>, <a href="#rfc.section.8.3"><b>8.3</b></a>, <a href="#rfc.xref.header.range.5">9.5.17</a>, <a href="#rfc.xref.header.range.6">C.8</a></li>
                      <li>Realm&nbsp;&nbsp;<a href="#rfc.section.8.5.2">8.5.2</a></li>
                      <li>recipient&nbsp;&nbsp;<a href="#rfc.iref.r.1"><b>2.1</b></a></li>
                      <li>Referer header field&nbsp;&nbsp;<a href="#rfc.xref.header.referer.1">4.8</a>, <a href="#rfc.xref.header.referer.2">8.6</a>, <a href="#rfc.section.8.6.2"><b>8.6.2</b></a>, <a href="#rfc.xref.header.referer.3">11.8</a></li>

--- a/draft-ietf-httpbis-semantics-latest.html
+++ b/draft-ietf-httpbis-semantics-latest.html
@@ -10481,6 +10481,9 @@ Content-Encoding: gzip
             <h3 id="rfc.section.C.8"><a href="#rfc.section.C.8">C.8.</a>&nbsp;<a href="#changes.since.06">Since draft-ietf-httpbis-semantics-06</a> <a class="self" href="https://tools.ietf.org/html/draft-ietf-httpbis-semantics-06" title="plain text">📄</a></h3>
             <div id="rfc.section.C.8.p.1">
                <ul>
+                  <li>In <a href="#header.range" id="rfc.xref.header.range.6" title="Range">Section 8.3</a>, explicitly reference the definition of representation data as including any content
+                     codings (&lt;<a href="https://github.com/httpwg/http-core/issues/11">https://github.com/httpwg/http-core/issues/11</a>&gt;)
+                  </li>
                   <li>In <a href="#header.via" id="rfc.xref.header.via.5" title="Via">Section 5.7.1</a>, simplify received-by grammar (and disallow comma character) (&lt;<a href="https://github.com/httpwg/http-core/issues/24">https://github.com/httpwg/http-core/issues/24</a>&gt;)
                   </li>
                   <li>In <a href="#field.names" title="Field Names">Section 4.3</a>, give guidance on interoperable field names (&lt;<a href="https://github.com/httpwg/http-core/issues/30">https://github.com/httpwg/http-core/issues/30</a>&gt;)
@@ -10524,11 +10527,8 @@ Content-Encoding: gzip
                   </li>
                   <li>In <a href="#intro.requirements" title="Requirements Notation">Section 1.1</a>, reference RFC 8174 as well (&lt;<a href="https://github.com/httpwg/http-core/issues/303">https://github.com/httpwg/http-core/issues/303</a>&gt;)
                   </li>
-                  <li>In <a href="#header.range" id="rfc.xref.header.range.6" title="Range">Section 8.3</a>, explicitly reference the definition of representation data as including any content
-                     codings (&lt;<a href="https://github.com/httpwg/http-core/issues/11">https://github.com/httpwg/http-core/issues/11</a>&gt;)
-                  </li>
                   <li>In <a href="#representations" title="Representations">Section 6</a>, explicitly reference 206 as one of the status codes that provide representation
-                     data
+                     data (&lt;<a href="https://github.com/httpwg/http-core/issues/325">https://github.com/httpwg/http-core/issues/325</a>&gt;)
                   </li>
                </ul>
             </div>

--- a/draft-ietf-httpbis-semantics-latest.html
+++ b/draft-ietf-httpbis-semantics-latest.html
@@ -606,7 +606,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
        content: "Fielding, et al.";
   }
   @bottom-center {
-       content: "Expires September 4, 2020";
+       content: "Expires September 7, 2020";
   }
   @bottom-right {
        content: "[Page " counter(page) "]";
@@ -651,7 +651,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
       <meta name="dcterms.creator" content="Fielding, R.">
       <meta name="dcterms.creator" content="Nottingham, M.">
       <meta name="dcterms.creator" content="Reschke, J. F.">
-      <meta name="dcterms.issued" content="2020-03-03">
+      <meta name="dcterms.issued" content="2020-03-06">
       <meta name="dct.replaces" content="urn:ietf:rfc:2818">
       <meta name="dct.replaces" content="urn:ietf:rfc:7230">
       <meta name="dct.replaces" content="urn:ietf:rfc:7231">
@@ -685,7 +685,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                   <td class="right">Fastly</td>
                </tr>
                <tr>
-                  <td class="left">Expires: September 4, 2020</td>
+                  <td class="left">Expires: September 7, 2020</td>
                   <td class="right">J. Reschke, Editor</td>
                </tr>
                <tr>
@@ -694,7 +694,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                </tr>
                <tr>
                   <td class="left"></td>
-                  <td class="right">March 3, 2020</td>
+                  <td class="right">March 6, 2020</td>
                </tr>
             </tbody>
          </table>
@@ -750,7 +750,7 @@ h1:hover > a.self, h2:hover > a.self, h3:hover > a.self, li:hover > a.self, p:ho
                Internet-Drafts as reference material or to cite them other than as “work in progress”.<a class="self" href="#rfc.boilerplate.1.p.3">¶</a></p>
          </div>
          <div id="rfc.boilerplate.1.p.4">
-            <p>This Internet-Draft will expire on September 4, 2020.<a class="self" href="#rfc.boilerplate.1.p.4">¶</a></p>
+            <p>This Internet-Draft will expire on September 7, 2020.<a class="self" href="#rfc.boilerplate.1.p.4">¶</a></p>
          </div>
       </section>
       <section id="rfc.copyrightnotice">
@@ -3214,9 +3214,8 @@ Host: www.example.org
                </div>
                <div id="rfc.section.5.7.2.p.8">
                   <p>A proxy <em class="bcp14">SHOULD NOT</em> modify header fields that provide information about the endpoints of the communication
-                     chain, the resource state, or the selected representation (other than the payload)
-                     unless the field's definition specifically allows such modification or the modification
-                     is deemed necessary for privacy or security.<a class="self" href="#rfc.section.5.7.2.p.8">¶</a></p>
+                     chain, the resource state, or the <a href="#representations" class="smpl">selected representation</a> (other than the payload) unless the field's definition specifically allows such modification
+                     or the modification is deemed necessary for privacy or security.<a class="self" href="#rfc.section.5.7.2.p.8">¶</a></p>
                </div>
             </section>
          </section>
@@ -3625,8 +3624,7 @@ Host: www.example.org
                      </ul>
                   </div>
                   <div id="rfc.section.6.1.4.2.p.6">
-                     <p>A client can limit the number of bytes requested without knowing the size of the selected
-                        representation. If the <a href="#rule.int-range" class="smpl">last-pos</a> value is absent, or if the value is greater than or equal to the current length of
+                     <p>A client can limit the number of bytes requested without knowing the size of the <a href="#representations" class="smpl">selected representation</a>. If the <a href="#rule.int-range" class="smpl">last-pos</a> value is absent, or if the value is greater than or equal to the current length of
                         the representation data, the byte range is interpreted as the remainder of the representation
                         (i.e., the server replaces the value of <a href="#rule.int-range" class="smpl">last-pos</a> with a value that is one less than the current length of the selected representation).<a class="self" href="#rfc.section.6.1.4.2.p.6">¶</a></p>
                   </div>
@@ -4144,9 +4142,8 @@ bytes=500-700,601-999
             <section id="header.content-range">
                <h4 id="rfc.section.6.3.4"><a href="#rfc.section.6.3.4">6.3.4.</a>&nbsp;<a href="#header.content-range">Content-Range</a></h4>
                <div id="rfc.section.6.3.4.p.1">
-                  <p>The "Content-Range" header field is sent in a single part <a href="#status.206" class="smpl">206 (Partial Content)</a> response to indicate the partial range of the selected representation enclosed as
-                     the message payload, sent in each part of a multipart 206 response to indicate the
-                     range enclosed within each body part, and sent in <a href="#status.416" class="smpl">416 (Range Not Satisfiable)</a> responses to provide information about the selected representation.<a class="self" href="#rfc.section.6.3.4.p.1">¶</a></p>
+                  <p>The "Content-Range" header field is sent in a single part <a href="#status.206" class="smpl">206 (Partial Content)</a> response to indicate the partial range of the <a href="#representations" class="smpl">selected representation</a> enclosed as the message payload, sent in each part of a multipart 206 response to
+                     indicate the range enclosed within each body part, and sent in <a href="#status.416" class="smpl">416 (Range Not Satisfiable)</a> responses to provide information about the selected representation.<a class="self" href="#rfc.section.6.3.4.p.1">¶</a></p>
                </div>
                <div id="rfc.section.6.3.4.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.61"></span><span id="rfc.iref.g.62"></span><span id="rfc.iref.g.63"></span><span id="rfc.iref.g.64"></span><span id="rfc.iref.g.65"></span><span id="rfc.iref.g.66"></span><span id="rfc.iref.g.67"></span>  <a href="#header.content-range" class="smpl">Content-Range</a>       = <a href="#range.units" class="smpl">range-unit</a> <a href="#core.rules" class="smpl">SP</a>
                         ( <a href="#header.content-range" class="smpl">range-resp</a> / <a href="#header.content-range" class="smpl">unsatisfied-range</a> )
@@ -4739,7 +4736,7 @@ Content-Range: exampleunit 11.2-14.3/25
                <h4 id="rfc.section.7.3.1"><a href="#rfc.section.7.3.1">7.3.1.</a>&nbsp;<a href="#GET">GET</a></h4>
                <div id="rfc.iref.g.69"></div>
                <div id="rfc.section.7.3.1.p.1">
-                  <p>The GET method requests transfer of a current selected representation for the <a href="#target.resource" class="smpl">target resource</a>. GET is the primary mechanism of information retrieval and the focus of almost all
+                  <p>The GET method requests transfer of a current <a href="#representations" class="smpl">selected representation</a> for the <a href="#target.resource" class="smpl">target resource</a>. GET is the primary mechanism of information retrieval and the focus of almost all
                      performance optimizations. Hence, when people speak of retrieving some identifiable
                      information via HTTP, they are generally referring to making a GET request.<a class="self" href="#rfc.section.7.3.1.p.1">¶</a></p>
                </div>
@@ -4782,8 +4779,7 @@ Content-Range: exampleunit 11.2-14.3/25
                <div id="rfc.section.7.3.2.p.1">
                   <p>The HEAD method is identical to GET except that the server <em class="bcp14">MUST NOT</em> send a message body in the response (i.e., the response terminates at the end of the
                      header section). The server <em class="bcp14">SHOULD</em> send the same header fields in response to a HEAD request as it would have sent if
-                     the request had been a GET, except that the payload header fields (<a href="#payload" title="Payload">Section 6.3</a>) <em class="bcp14">MAY</em> be omitted. This method can be used for obtaining metadata about the selected representation
-                     without transferring the representation data and is often used for testing hypertext
+                     the request had been a GET, except that the payload header fields (<a href="#payload" title="Payload">Section 6.3</a>) <em class="bcp14">MAY</em> be omitted. This method can be used for obtaining metadata about the <a href="#representations" class="smpl">selected representation</a> without transferring the representation data and is often used for testing hypertext
                      links for validity, accessibility, and recent modification.<a class="self" href="#rfc.section.7.3.2.p.1">¶</a></p>
                </div>
                <div id="rfc.section.7.3.2.p.2">
@@ -5394,7 +5390,7 @@ Expect: 100-continue
                   a whole (its current value set) or the state as observed in a previously obtained
                   representation (one value in that set). A resource might have multiple current representations,
                   each with its own observable state. The conditional request mechanisms assume that
-                  the mapping of requests to a "selected representation" (<a href="#representations" title="Representations">Section 6</a>) will be consistent over time if the server intends to take advantage of conditionals.
+                  the mapping of requests to a <a href="#representations" class="smpl">selected representation</a> (<a href="#representations" title="Representations">Section 6</a>) will be consistent over time if the server intends to take advantage of conditionals.
                   Regardless, if the mapping is inconsistent and the server is unable to select the
                   appropriate representation, then no harm will result when the precondition evaluates
                   to false.<a class="self" href="#rfc.section.8.2.p.3">¶</a></p>
@@ -5405,7 +5401,7 @@ Expect: 100-continue
                   will not be applied if the precondition evaluates to false. Each precondition defined
                   by this specification consists of a comparison between a set of validators obtained
                   from prior representations of the target resource to the current state of validators
-                  for the <a href="#representations" class="smpl">selected representation</a> (<a href="#response.validator" title="Validators">Section 10.2</a>). Hence, these preconditions evaluate whether the state of the target resource has
+                  for the selected representation (<a href="#response.validator" title="Validators">Section 10.2</a>). Hence, these preconditions evaluate whether the state of the target resource has
                   changed since a given state known by the client. The effect of such an evaluation
                   depends on the method semantics and choice of conditional, as defined in <a href="#evaluation" title="Evaluation">Section 8.2.1</a>.<a class="self" href="#rfc.section.8.2.p.4">¶</a></p>
             </div>
@@ -5554,8 +5550,7 @@ Expect: 100-continue
                         </div> 
                         <div>
                            <ul>
-                              <li>if the validator matches and the Range specification is applicable to the selected
-                                 representation, respond <a href="#status.206" class="smpl">206 (Partial Content)</a></li>
+                              <li>if the validator matches and the Range specification is applicable to the <a href="#representations" class="smpl">selected representation</a>, respond <a href="#status.206" class="smpl">206 (Partial Content)</a></li>
                            </ul>
                         </div> 
                      </li>
@@ -5633,8 +5628,7 @@ Expect: 100-continue
                <div id="rfc.section.8.2.4.p.1">
                   <p>The "If-None-Match" header field makes the request method conditional on a recipient
                      cache or origin server either not having any current representation of the target
-                     resource, when the field value is "*", or having a selected representation with an
-                     entity-tag that does not match any of those listed in the field value.<a class="self" href="#rfc.section.8.2.4.p.1">¶</a></p>
+                     resource, when the field value is "*", or having a <a href="#representations" class="smpl">selected representation</a> with an entity-tag that does not match any of those listed in the field value.<a class="self" href="#rfc.section.8.2.4.p.1">¶</a></p>
                </div>
                <div id="rfc.section.8.2.4.p.2">
                   <p>A recipient <em class="bcp14">MUST</em> use the weak comparison function when comparing entity-tags for If-None-Match (<a href="#entity.tag.comparison" title="Comparison">Section 10.2.3.2</a>), since weak entity-tags can be used for cache validation even if there have been
@@ -5683,9 +5677,8 @@ Expect: 100-continue
                <h4 id="rfc.section.8.2.5"><a href="#rfc.section.8.2.5">8.2.5.</a>&nbsp;<a href="#header.if-modified-since">If-Modified-Since</a></h4>
                <div id="rfc.section.8.2.5.p.1">
                   <p>The "If-Modified-Since" header field makes a GET or HEAD request method conditional
-                     on the selected representation's modification date being more recent than the date
-                     provided in the field value. Transfer of the selected representation's data is avoided
-                     if that data has not changed.<a class="self" href="#rfc.section.8.2.5.p.1">¶</a></p>
+                     on the <a href="#representations" class="smpl">selected representation</a>'s modification date being more recent than the date provided in the field value.
+                     Transfer of the selected representation's data is avoided if that data has not changed.<a class="self" href="#rfc.section.8.2.5.p.1">¶</a></p>
                </div>
                <div id="rfc.section.8.2.5.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.74"></span>  <a href="#header.if-modified-since" class="smpl">If-Modified-Since</a> = <a href="#http.date" class="smpl">HTTP-date</a>
 </pre></div>
@@ -5742,9 +5735,8 @@ Expect: 100-continue
             <section id="header.if-unmodified-since">
                <h4 id="rfc.section.8.2.6"><a href="#rfc.section.8.2.6">8.2.6.</a>&nbsp;<a href="#header.if-unmodified-since">If-Unmodified-Since</a></h4>
                <div id="rfc.section.8.2.6.p.1">
-                  <p>The "If-Unmodified-Since" header field makes the request method conditional on the
-                     selected representation's last modification date being earlier than or equal to the
-                     date provided in the field value. This field accomplishes the same purpose as <a href="#header.if-match" class="smpl">If-Match</a> for cases where the user agent does not have an entity-tag for the representation.<a class="self" href="#rfc.section.8.2.6.p.1">¶</a></p>
+                  <p>The "If-Unmodified-Since" header field makes the request method conditional on the <a href="#representations" class="smpl">selected representation</a>'s last modification date being earlier than or equal to the date provided in the
+                     field value. This field accomplishes the same purpose as <a href="#header.if-match" class="smpl">If-Match</a> for cases where the user agent does not have an entity-tag for the representation.<a class="self" href="#rfc.section.8.2.6.p.1">¶</a></p>
                </div>
                <div id="rfc.section.8.2.6.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.75"></span>  <a href="#header.if-unmodified-since" class="smpl">If-Unmodified-Since</a> = <a href="#http.date" class="smpl">HTTP-date</a>
 </pre></div>
@@ -5792,8 +5784,7 @@ Expect: 100-continue
                <h4 id="rfc.section.8.2.7"><a href="#rfc.section.8.2.7">8.2.7.</a>&nbsp;<a href="#header.if-range">If-Range</a></h4>
                <div id="rfc.section.8.2.7.p.1">
                   <p>The "If-Range" header field provides a special conditional request mechanism that
-                     is similar to the <a href="#header.if-match" class="smpl">If-Match</a> and <a href="#header.if-unmodified-since" class="smpl">If-Unmodified-Since</a> header fields but that instructs the recipient to ignore the <a href="#header.range" class="smpl">Range</a> header field if the validator doesn't match, resulting in transfer of the new selected
-                     representation instead of a <a href="#status.412" class="smpl">412 (Precondition Failed)</a> response.<a class="self" href="#rfc.section.8.2.7.p.1">¶</a></p>
+                     is similar to the <a href="#header.if-match" class="smpl">If-Match</a> and <a href="#header.if-unmodified-since" class="smpl">If-Unmodified-Since</a> header fields but that instructs the recipient to ignore the <a href="#header.range" class="smpl">Range</a> header field if the validator doesn't match, resulting in transfer of the new <a href="#representations" class="smpl">selected representation</a> instead of a <a href="#status.412" class="smpl">412 (Precondition Failed)</a> response.<a class="self" href="#rfc.section.8.2.7.p.1">¶</a></p>
                </div>
                <div id="rfc.section.8.2.7.p.2">
                   <p>If a client has a partial copy of a representation and wishes to have an up-to-date
@@ -5830,8 +5821,7 @@ Expect: 100-continue
             <h3 id="rfc.section.8.3"><a href="#rfc.section.8.3">8.3.</a>&nbsp;<a href="#header.range">Range</a></h3>
             <div id="rfc.section.8.3.p.1">
                <p>The "Range" header field on a GET request modifies the method semantics to request
-                  transfer of only one or more subranges of the selected representation data, rather
-                  than the entire selected representation data.<a class="self" href="#rfc.section.8.3.p.1">¶</a></p>
+                  transfer of only one or more subranges of the <a href="#representations" class="smpl">selected representation</a> data, rather than the entire selected representation.<a class="self" href="#rfc.section.8.3.p.1">¶</a></p>
             </div>
             <div id="rfc.section.8.3.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.77"></span>  <a href="#header.range" class="smpl">Range</a> = <a href="#rule.ranges-specifier" class="smpl">ranges-specifier</a>
 </pre></div>
@@ -7257,7 +7247,7 @@ Expect: 100-continue
                <h4 id="rfc.section.9.3.7"><a href="#rfc.section.9.3.7">9.3.7.</a>&nbsp;<a href="#status.206">206 Partial Content</a></h4>
                <div id="rfc.section.9.3.7.p.1">
                   <p>The <dfn>206 (Partial Content)</dfn> status code indicates that the server is successfully fulfilling a range request for
-                     the target resource by transferring one or more parts of the selected representation.<a class="self" href="#rfc.section.9.3.7.p.1">¶</a></p>
+                     the target resource by transferring one or more parts of the <a href="#representations" class="smpl">selected representation</a>.<a class="self" href="#rfc.section.9.3.7.p.1">¶</a></p>
                </div>
                <div id="rfc.section.9.3.7.p.2">
                   <p>When a 206 response is generated, the server <em class="bcp14">MUST</em> generate the following header fields, in addition to those required in the subsections
@@ -7829,9 +7819,8 @@ Content-Range: bytes 7000-7999/8000
             <section id="status.416">
                <h4 id="rfc.section.9.5.17"><a href="#rfc.section.9.5.17">9.5.17.</a>&nbsp;<a href="#status.416">416 Range Not Satisfiable</a></h4>
                <div id="rfc.section.9.5.17.p.1">
-                  <p>The <dfn>416 (Range Not Satisfiable)</dfn> status code indicates that none of the ranges in the request's <a href="#header.range" class="smpl">Range</a> header field (<a href="#header.range" id="rfc.xref.header.range.5" title="Range">Section 8.3</a>) overlap the current extent of the selected representation or that the set of ranges
-                     requested has been rejected due to invalid ranges or an excessive request of small
-                     or overlapping ranges.<a class="self" href="#rfc.section.9.5.17.p.1">¶</a></p>
+                  <p>The <dfn>416 (Range Not Satisfiable)</dfn> status code indicates that none of the ranges in the request's <a href="#header.range" class="smpl">Range</a> header field (<a href="#header.range" id="rfc.xref.header.range.5" title="Range">Section 8.3</a>) overlap the current extent of the <a href="#representations" class="smpl">selected representation</a> or that the set of ranges requested has been rejected due to invalid ranges or an
+                     excessive request of small or overlapping ranges.<a class="self" href="#rfc.section.9.5.17.p.1">¶</a></p>
                </div>
                <div id="rfc.section.9.5.17.p.2">
                   <p>For byte ranges, failing to overlap the current extent means that the <a href="#rule.int-range" class="smpl">first-pos</a> of all of the <a href="#rule.ranges-specifier" class="smpl">range-spec</a> values were greater than or equal to the current length of the selected representation.
@@ -8534,8 +8523,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
                <h4 id="rfc.section.10.2.2"><a href="#rfc.section.10.2.2">10.2.2.</a>&nbsp;<a href="#header.last-modified">Last-Modified</a></h4>
                <div id="rfc.section.10.2.2.p.1">
                   <p>The "Last-Modified" header field in a response provides a timestamp indicating the
-                     date and time at which the origin server believes the selected representation was
-                     last modified, as determined at the conclusion of handling the request.<a class="self" href="#rfc.section.10.2.2.p.1">¶</a></p>
+                     date and time at which the origin server believes the <a href="#representations" class="smpl">selected representation</a> was last modified, as determined at the conclusion of handling the request.<a class="self" href="#rfc.section.10.2.2.p.1">¶</a></p>
                </div>
                <div id="rfc.section.10.2.2.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.122"></span>  <a href="#header.last-modified" class="smpl">Last-Modified</a> = <a href="#http.date" class="smpl">HTTP-date</a>
 </pre></div>
@@ -8632,8 +8620,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
             <section id="header.etag">
                <h4 id="rfc.section.10.2.3"><a href="#rfc.section.10.2.3">10.2.3.</a>&nbsp;<a href="#header.etag">ETag</a></h4>
                <div id="rfc.section.10.2.3.p.1">
-                  <p>The "ETag" field in a response provides the current entity-tag for the selected representation,
-                     as determined at the conclusion of handling the request. An entity-tag is an opaque
+                  <p>The "ETag" field in a response provides the current entity-tag for the <a href="#representations" class="smpl">selected representation</a>, as determined at the conclusion of handling the request. An entity-tag is an opaque
                      validator for differentiating between multiple representations of the same resource,
                      regardless of whether those multiple representations are due to resource state changes
                      over time, content negotiation resulting in multiple representations being valid at
@@ -11211,7 +11198,7 @@ Content-Encoding: gzip
                <li><a id="rfc.index.S" href="#rfc.index.S"><b>S</b></a><ul>
                      <li>safe&nbsp;&nbsp;<a href="#rfc.section.7.2.1"><b>7.2.1</b></a></li>
                      <li>secured&nbsp;&nbsp;<a href="#rfc.section.2.5.2"><b>2.5.2</b></a></li>
-                     <li>selected representation&nbsp;&nbsp;<a href="#rfc.section.6"><b>6</b></a>, <a href="#rfc.iref.s.3"><b>8.2</b></a>, <a href="#rfc.section.10.2">10.2</a></li>
+                     <li>selected representation&nbsp;&nbsp;<a href="#rfc.section.6"><b>6</b></a>, <a href="#rfc.iref.s.3">8.2</a>, <a href="#rfc.section.10.2">10.2</a></li>
                      <li>sender&nbsp;&nbsp;<a href="#rfc.iref.s.2"><b>2.1</b></a></li>
                      <li>server&nbsp;&nbsp;<a href="#rfc.section.2.1"><b>2.1</b></a></li>
                      <li>Server header field&nbsp;&nbsp;<a href="#rfc.xref.header.server.1">4.8</a>, <a href="#rfc.xref.header.server.2">10.4</a>, <a href="#rfc.section.10.4.3"><b>10.4.3</b></a>, <a href="#rfc.xref.header.server.3">11.10</a></li>

--- a/draft-ietf-httpbis-semantics-latest.html
+++ b/draft-ietf-httpbis-semantics-latest.html
@@ -3238,7 +3238,7 @@ Host: www.example.org
          <div id="rfc.section.6.p.3">
             <p>An origin server might be provided with, or be capable of generating, multiple representations
                that are each intended to reflect the current state of a <a href="#target.resource" class="smpl">target resource</a>. In such cases, some algorithm is used by the origin server to select one of those
-               representations as most applicable to a given request, usually based on <a href="#content.negotiation" class="smpl">content negotiation</a>. This "<dfn>selected representation</dfn>" is used to provide the data and metadata for evaluating conditional requests (<a href="#preconditions" title="Preconditions">Section 8.2</a>) and constructing the payload for <a href="#status.200" class="smpl">200 (OK)</a> and <a href="#status.304" class="smpl">304 (Not Modified)</a> responses to GET (<a href="#GET" id="rfc.xref.GET.2" title="GET">Section 7.3.1</a>).<a class="self" href="#rfc.section.6.p.3">¶</a></p>
+               representations as most applicable to a given request, usually based on <a href="#content.negotiation" class="smpl">content negotiation</a>. This "<dfn>selected representation</dfn>" is used to provide the data and metadata for evaluating conditional requests (<a href="#preconditions" title="Preconditions">Section 8.2</a>) and constructing the payload for <a href="#status.200" class="smpl">200 (OK)</a>, <a href="#status.206" class="smpl">206 (Partial Content)</a>, and <a href="#status.304" class="smpl">304 (Not Modified)</a> responses to GET (<a href="#GET" id="rfc.xref.GET.2" title="GET">Section 7.3.1</a>).<a class="self" href="#rfc.section.6.p.3">¶</a></p>
          </div>
          <section id="representation.data">
             <h3 id="rfc.section.6.1"><a href="#rfc.section.6.1">6.1.</a>&nbsp;<a href="#representation.data">Representation Data</a></h3>
@@ -5821,7 +5821,7 @@ Expect: 100-continue
             <h3 id="rfc.section.8.3"><a href="#rfc.section.8.3">8.3.</a>&nbsp;<a href="#header.range">Range</a></h3>
             <div id="rfc.section.8.3.p.1">
                <p>The "Range" header field on a GET request modifies the method semantics to request
-                  transfer of only one or more subranges of the <a href="#representations" class="smpl">selected representation</a> data, rather than the entire selected representation.<a class="self" href="#rfc.section.8.3.p.1">¶</a></p>
+                  transfer of only one or more subranges of the selected representation data (<a href="#representation.data" title="Representation Data">Section 6.1</a>), rather than the entire <a href="#representations" class="smpl">selected representation</a>.<a class="self" href="#rfc.section.8.3.p.1">¶</a></p>
             </div>
             <div id="rfc.section.8.3.p.2"><pre class="inline prettyprint lang-ietf_abnf"><span id="rfc.iref.g.77"></span>  <a href="#header.range" class="smpl">Range</a> = <a href="#rule.ranges-specifier" class="smpl">ranges-specifier</a>
 </pre></div>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12318,6 +12318,8 @@ Content-Encoding: gzip
   <li>In <xref target="header.host"/>, make explicit requirements on origin server to use authority from absolute-form when available (<eref target="https://github.com/httpwg/http-core/issues/191"/>)</li>
   <li>In <xref target="http.uri"/>, <xref target="https.uri"/>, <xref target="origin"/>, and <xref target="authoritative.access"/>, refactored schemes to define origin and authoritative access to an origin server for both "http" and "https" URIs to account for alternative services and secured connections that are not necessarily based on TCP (<eref target="https://github.com/httpwg/http-core/issues/237"/>)</li>
   <li>In <xref target="intro.requirements"/>, reference RFC 8174 as well (<eref target="https://github.com/httpwg/http-core/issues/303"/>)</li>
+  <li>In <xref target="header.range"/>, explicitly reference the definition of representation data as including any content codings (<eref target="https://github.com/httpwg/http-core/issues/11"/>)</li>
+  <li>In <xref target="representations"/>, explicitly reference 206 as one of the status codes that provide representation data</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2760,7 +2760,8 @@ Host: www.example.org
    to a given request, usually based on <x:ref>content negotiation</x:ref>.
    This "<x:dfn>selected representation</x:dfn>" is used to provide the data
    and metadata for evaluating conditional requests (<xref target="preconditions"/>)
-   and constructing the payload for <x:ref>200 (OK)</x:ref> and
+   and constructing the payload for <x:ref>200 (OK)</x:ref>,
+   <x:ref>206 (Partial Content)</x:ref>, and
    <x:ref>304 (Not Modified)</x:ref> responses to GET (<xref target="GET"/>).
 </t>
 
@@ -5942,8 +5943,8 @@ Expect: 100-continue
 <t>
    The "Range" header field on a GET request modifies the method semantics to
    request transfer of only one or more subranges of the
-   <x:ref>selected representation</x:ref> data, rather than the entire
-   selected representation.
+   selected representation data (<xref target="representation.data"/>),
+   rather than the entire <x:ref>selected representation</x:ref>.
 </t>
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="Range"/>
   <x:ref>Range</x:ref> = <x:ref>ranges-specifier</x:ref>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12316,6 +12316,7 @@ Content-Encoding: gzip
 
 <section title="Since draft-ietf-httpbis-semantics-06" anchor="changes.since.06">
 <ul x:when-empty="None yet.">
+  <li>In <xref target="header.range"/>, explicitly reference the definition of representation data as including any content codings (<eref target="https://github.com/httpwg/http-core/issues/11"/>)</li>
   <li>In <xref target="header.via"/>, simplify received-by grammar (and disallow comma character) (<eref target="https://github.com/httpwg/http-core/issues/24"/>)</li>
   <li>In <xref target="field.names"/>, give guidance on interoperable field names (<eref target="https://github.com/httpwg/http-core/issues/30"/>)</li>
   <li>In <xref target="whitespace"/>, define the semantics and possible replacement of whitespace when it is known to occur (<eref target="https://github.com/httpwg/http-core/issues/53"/>)</li>
@@ -12334,8 +12335,7 @@ Content-Encoding: gzip
   <li>In <xref target="header.host"/>, make explicit requirements on origin server to use authority from absolute-form when available (<eref target="https://github.com/httpwg/http-core/issues/191"/>)</li>
   <li>In <xref target="http.uri"/>, <xref target="https.uri"/>, <xref target="origin"/>, and <xref target="authoritative.access"/>, refactored schemes to define origin and authoritative access to an origin server for both "http" and "https" URIs to account for alternative services and secured connections that are not necessarily based on TCP (<eref target="https://github.com/httpwg/http-core/issues/237"/>)</li>
   <li>In <xref target="intro.requirements"/>, reference RFC 8174 as well (<eref target="https://github.com/httpwg/http-core/issues/303"/>)</li>
-  <li>In <xref target="header.range"/>, explicitly reference the definition of representation data as including any content codings (<eref target="https://github.com/httpwg/http-core/issues/11"/>)</li>
-  <li>In <xref target="representations"/>, explicitly reference 206 as one of the status codes that provide representation data</li>
+  <li>In <xref target="representations"/>, explicitly reference 206 as one of the status codes that provide representation data (<eref target="https://github.com/httpwg/http-core/issues/325"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2723,7 +2723,7 @@ Host: www.example.org
 <t>
    A proxy &SHOULD-NOT; modify header fields that provide information about
    the endpoints of the communication chain, the resource state, or the
-   selected representation (other than the payload) unless the field's
+   <x:ref>selected representation</x:ref> (other than the payload) unless the field's
    definition specifically allows such modification or the modification is
    deemed necessary for privacy or security.
 </t>
@@ -3249,7 +3249,7 @@ bytes=500-999
 </ul>
 <t>
    A client can limit the number of bytes requested without knowing the size
-   of the selected representation.
+   of the <x:ref>selected representation</x:ref>.
    If the <x:ref>last-pos</x:ref> value is absent, or if the value is
    greater than or equal to the current length of the representation data, the
    byte range is interpreted as the remainder of the representation (i.e., the
@@ -3882,7 +3882,7 @@ bytes=500-700,601-999
 <t>
    The "Content-Range" header field is sent in a single part
    <x:ref>206 (Partial Content)</x:ref> response to indicate the partial range
-   of the selected representation enclosed as the message payload, sent in
+   of the <x:ref>selected representation</x:ref> enclosed as the message payload, sent in
    each part of a multipart 206 response to indicate the range enclosed within
    each body part, and sent in <x:ref>416 (Range Not Satisfiable)</x:ref>
    responses to provide information about the selected representation.
@@ -4569,7 +4569,7 @@ Content-Range: exampleunit 11.2-14.3/25
   </rdf:Description>
   <iref primary="true" item="GET method" x:for-anchor=""/>
 <t>
-   The GET method requests transfer of a current selected representation for
+   The GET method requests transfer of a current <x:ref>selected representation</x:ref> for
    the <x:ref>target resource</x:ref>. GET is the primary mechanism of
    information retrieval and the focus of almost all performance
    optimizations. Hence, when people speak of retrieving some identifiable
@@ -4631,7 +4631,7 @@ Content-Range: exampleunit 11.2-14.3/25
    in response to a HEAD request as it would have sent if the request had been
    a GET, except that the payload header fields (<xref target="payload"/>)
    &MAY; be omitted. This method can be used for obtaining metadata about the
-   selected representation without transferring the representation data and is
+   <x:ref>selected representation</x:ref> without transferring the representation data and is
    often used for testing hypertext links for validity, accessibility, and
    recent modification.
 </t>
@@ -5404,13 +5404,13 @@ Expect: 100-continue
    the "lost update" problem: one client accidentally overwriting
    the work of another client that has been acting in parallel.
 </t>
-<t><iref primary="true" item="selected representation"/>
+<t><iref primary="false" item="selected representation"/>
    Conditional request preconditions are based on the state of the target
    resource as a whole (its current value set) or the state as observed
    in a previously obtained representation (one value in that set).
    A resource might have multiple current representations, each with its
    own observable state.  The conditional request mechanisms assume that
-   the mapping of requests to a "selected representation" (<xref target="representations"/>)
+   the mapping of requests to a <x:ref>selected representation</x:ref> (<xref target="representations"/>)
    will be consistent over time if the server intends to take advantage of
    conditionals. Regardless, if the mapping is inconsistent and the server is
    unable to select the appropriate representation, then no harm will result
@@ -5423,7 +5423,7 @@ Expect: 100-continue
    precondition evaluates to false. Each precondition defined by this
    specification consists of a comparison between a set of validators obtained
    from prior representations of the target resource to the current state of
-   validators for the <x:ref>selected representation</x:ref>
+   validators for the selected representation
    (<xref target="response.validator"/>). Hence, these preconditions evaluate
    whether the state of the target resource has changed since a given state
    known by the client. The effect of such an evaluation depends on the method
@@ -5566,7 +5566,7 @@ Expect: 100-continue
      evaluate the <x:ref>If-Range</x:ref> precondition:</t>
      <ul>
        <li>if the validator matches and the Range specification is
-           applicable to the selected representation, respond
+           applicable to the <x:ref>selected representation</x:ref>, respond
            <x:ref>206 (Partial Content)</x:ref></li>
      </ul>
    </li>
@@ -5657,7 +5657,7 @@ Expect: 100-continue
    The "If-None-Match" header field makes the request method conditional on
    a recipient cache or origin server either not having any current
    representation of the target resource, when the field value is "*", or
-   having a selected representation with an entity-tag that does not match any
+   having a <x:ref>selected representation</x:ref> with an entity-tag that does not match any
    of those listed in the field value.
 </t>
 <t>
@@ -5725,7 +5725,7 @@ Expect: 100-continue
   <x:anchor-alias value="If-Modified-Since"/>
 <t>
    The "If-Modified-Since" header field makes a GET or HEAD request method
-   conditional on the selected representation's modification date being more
+   conditional on the <x:ref>selected representation</x:ref>'s modification date being more
    recent than the date provided in the field value. Transfer of the selected
    representation's data is avoided if that data has not changed.
 </t>
@@ -5805,7 +5805,7 @@ Expect: 100-continue
   <x:anchor-alias value="If-Unmodified-Since"/>
 <t>
    The "If-Unmodified-Since" header field makes the request method conditional
-   on the selected representation's last modification date being earlier than or
+   on the <x:ref>selected representation</x:ref>'s last modification date being earlier than or
    equal to the date provided in the field value. This field accomplishes the
    same purpose as <x:ref>If-Match</x:ref> for cases where the user agent does
    not have an entity-tag for the representation.
@@ -5876,7 +5876,7 @@ Expect: 100-continue
    mechanism that is similar to the <x:ref>If-Match</x:ref> and
    <x:ref>If-Unmodified-Since</x:ref> header fields but that instructs the
    recipient to ignore the <x:ref>Range</x:ref> header field if the validator
-   doesn't match, resulting in transfer of the new selected representation
+   doesn't match, resulting in transfer of the new <x:ref>selected representation</x:ref>
    instead of a <x:ref>412 (Precondition Failed)</x:ref> response.
 </t>
 <t>
@@ -5941,8 +5941,9 @@ Expect: 100-continue
   <x:anchor-alias value="Range"/>
 <t>
    The "Range" header field on a GET request modifies the method semantics to
-   request transfer of only one or more subranges of the selected
-   representation data, rather than the entire selected representation data.
+   request transfer of only one or more subranges of the
+   <x:ref>selected representation</x:ref> data, rather than the entire
+   selected representation.
 </t>
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="Range"/>
   <x:ref>Range</x:ref> = <x:ref>ranges-specifier</x:ref>
@@ -7685,7 +7686,7 @@ Expect: 100-continue
 <t>
    The <x:dfn>206 (Partial Content)</x:dfn> status code indicates that the
    server is successfully fulfilling a range request for the target resource
-   by transferring one or more parts of the selected representation.
+   by transferring one or more parts of the <x:ref>selected representation</x:ref>.
 </t>
 <t>
    When a 206 response is generated, the server &MUST; generate the following
@@ -8509,8 +8510,9 @@ Content-Range: bytes 7000-7999/8000
 <t>
    The <x:dfn>416 (Range Not Satisfiable)</x:dfn> status code indicates that
    none of the ranges in the request's <x:ref>Range</x:ref> header field
-   (<xref target="header.range"/>) overlap the current extent of the selected
-   representation or that the set of ranges requested has been rejected due to
+   (<xref target="header.range"/>) overlap the current extent of the
+   <x:ref>selected representation</x:ref> or that the set of ranges requested
+   has been rejected due to
    invalid ranges or an excessive request of small or overlapping ranges.
 </t>
 <t>
@@ -9389,7 +9391,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
 <t>
    The "Last-Modified" header field in a response provides a timestamp
    indicating the date and time at which the origin server believes the
-   selected representation was last modified, as determined at the conclusion
+   <x:ref>selected representation</x:ref> was last modified, as determined at the conclusion
    of handling the request.
 </t>
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="Last-Modified"/>
@@ -9505,7 +9507,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
   <x:anchor-alias value="etagc"/>
 <t>
    The "ETag" field in a response provides the current entity-tag for
-   the selected representation, as determined at the conclusion of handling
+   the <x:ref>selected representation</x:ref>, as determined at the conclusion of handling
    the request.
    An entity-tag is an opaque validator for differentiating between
    multiple representations of the same resource, regardless of whether


### PR DESCRIPTION
add cross references to clarify that Range works on representation data and that such data might have a content coding; fixes #11 