### PR TITLE
Don't rely on the HTTP/1.1 Messaging specification to define "message"

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -381,8 +381,7 @@
 <iref primary="true" item="connection"/>
 <t>
    HTTP is a stateless request/response protocol that operates by exchanging
-   <x:dfn>messages</x:dfn> (<xref target="http.message"/>) across a reliable
-   transport- or session-layer
+   <x:dfn>messages</x:dfn> across a reliable transport- or session-layer
    "<x:dfn>connection</x:dfn>" (<xref target="connection.management"/>).
    An HTTP "<x:dfn>client</x:dfn>" is a program that establishes a connection
    to a server for the purpose of sending one or more HTTP requests.
@@ -12337,6 +12336,7 @@ Content-Encoding: gzip
 
 <section title="Since draft-ietf-httpbis-semantics-07" anchor="changes.since.07">
 <ul x:when-empty="None yet.">
+   <li>In <xref target="operation"/>, don't rely on the HTTP/1.1 Messaging specification to define "message" (<eref target="https://github.com/httpwg/http-core/issues/311"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
Fixes #311