### PR TITLE
Make text body narrower for readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ diff00:
           egrep -v -- '^<\!-- ' > diffs/diff_auth_since_00.html
 
 %.html: %.xml $(stylesheet)
-	$(saxon) $< $(xreffer) | $(saxon) - $(stylesheet) xml2rfc-ext-maxwidth=900 xml2rfc-ext-styles="ff-noto ffb-sans-serif fft-sans-serif header-bw" xml2rfc-ext-paragraph-links=yes | awk -f lib/html5doctype.awk > $@
+	$(saxon) $< $(xreffer) | $(saxon) - $(stylesheet) xml2rfc-ext-maxwidth=700 xml2rfc-ext-styles="ff-noto ffb-sans-serif fft-sans-serif header-bw" xml2rfc-ext-paragraph-links=yes | awk -f lib/html5doctype.awk > $@
 
 $(bd)/%.redxml: %.xml $(reduction)
 	$(saxon) $< $(xreffer) | $(saxon) - $(reduction) > $@


### PR DESCRIPTION
Currently we have about 110+ characters per line;
broadly accepted norms for readability are 55-65.

This takes it to about 85.