### PR TITLE
Qualify requirement on applying conditionals

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5687,7 +5687,7 @@ Expect: 100-continue
 </t>
 <t>
    An origin server that receives an If-Match header field &MUST; evaluate the
-   condition prior to performing the method (<xref target="evaluation"/>).
+   condition prior to performing the method (when applicable; see <xref target="evaluation"/>).
 </t>
 <t>
    To evaluate a received If-Match header field:
@@ -5778,7 +5778,7 @@ Expect: 100-continue
 <t>
    An origin server that receives an If-None-Match header field &MUST;
    evaluate the condition prior to performing the method
-   (<xref target="evaluation"/>).
+   (when applicable; see <xref target="evaluation"/>).
 </t>
 <t>
    To evaluate a received If-None-Match header field:
@@ -5876,7 +5876,7 @@ Expect: 100-continue
 <t>
    An origin server that receives an If-Modified-Since header field &SHOULD;
    evaluate the condition prior to performing the method
-   (<xref target="evaluation"/>).
+   (when applicable; see <xref target="evaluation"/>).
    The origin server &SHOULD-NOT; perform the requested method if the selected
    representation's last modification date is earlier than or equal to the
    date provided in the field value; instead, the origin server &SHOULD;
@@ -5938,7 +5938,7 @@ Expect: 100-continue
 <t>
    An origin server that receives an If-Unmodified-Since header field &MUST;
    evaluate the condition prior to performing the method
-   (<xref target="evaluation"/>).
+   (when applicable; see <xref target="evaluation"/>).
    The origin server &MUST-NOT; perform the requested method if the selected
    representation's last modification date is more recent than the date
    provided in the field value; instead the origin server &MUST; respond with either

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5719,7 +5719,7 @@ Expect: 100-continue
 </t>
 <t>
    An origin server that receives an If-Match header field &MUST; evaluate the
-   condition prior to performing the method (when applicable; see <xref target="evaluation"/>).
+   condition as per <xref target="evaluation"/> prior to performing the method.
 </t>
 <t>
    To evaluate a received If-Match header field:
@@ -5809,8 +5809,7 @@ Expect: 100-continue
 </t>
 <t>
    An origin server that receives an If-None-Match header field &MUST;
-   evaluate the condition prior to performing the method
-   (when applicable; see <xref target="evaluation"/>).
+   evaluate the condition as per <xref target="evaluation"/> prior to performing the method.
 </t>
 <t>
    To evaluate a received If-None-Match header field:
@@ -5907,8 +5906,7 @@ Expect: 100-continue
 </t>
 <t>
    An origin server that receives an If-Modified-Since header field &SHOULD;
-   evaluate the condition prior to performing the method
-   (when applicable; see <xref target="evaluation"/>).
+   evaluate the condition as per <xref target="evaluation"/> prior to performing the method.
    The origin server &SHOULD-NOT; perform the requested method if the selected
    representation's last modification date is earlier than or equal to the
    date provided in the field value; instead, the origin server &SHOULD;
@@ -5969,7 +5967,7 @@ Expect: 100-continue
 </t>
 <t>
    An origin server that receives an If-Unmodified-Since header field &MUST;
-   evaluate the condition (when applicable; see <xref target="evaluation"/>) prior to performing
+   evaluate the condition as per <xref target="evaluation"/> prior to performing
    the method.
 </t>
 <t>


### PR DESCRIPTION
based upon existing requirement in evaluation.

I think this is editorial, because it's just referencing an already-existing requirement there.

Fixes #358.