### PR TITLE
Don't claim Transfer-Encoding is in HTTP/2.

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1066,11 +1066,11 @@ https://www.example.org
    implementations advertising only HTTP/1.0 support will not understand
    how to process a transfer-encoded payload.
    A client &MUST-NOT; send a request containing Transfer-Encoding unless it
-   knows the server will handle HTTP/1.1 (or later) requests; such knowledge
+   knows the server will handle HTTP/1.1 requests (or later minor revisions); such knowledge
    might be in the form of specific user configuration or by remembering the
    version of a prior received response.
    A server &MUST-NOT; send a response containing Transfer-Encoding unless
-   the corresponding request indicates HTTP/1.1 (or later).
+   the corresponding request indicates HTTP/1.1 (or later minor revisions).
 </t>
 <t>
    A server that receives a request message with a transfer coding it does
@@ -3519,6 +3519,7 @@ Upgrade: websocket
    <li>Move TE: trailers into <xref target="Semantics"/> (<eref target="https://github.com/httpwg/http-core/issues/18"/>)</li>
    <li>In <xref target="message.body.length"/>, adjust requirements for handling multiple content-length values (<eref target="https://github.com/httpwg/http-core/issues/59"/>)</li>
    <li>Throughout, replace "effective request URI" with "target URI" (<eref target="https://github.com/httpwg/http-core/issues/259"/>)</li>
+   <li>In <xref target="field.transfer-encoding"/>, don't claim Transfer-Encoding is supported by HTTP/2 or later (<eref target="https://github.com/httpwg/http-core/issues/297"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
Fixes #297.