### PR TITLE
Prohibit bare CRs in header section

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -3414,6 +3414,10 @@ Upgrade: websocket
    connection management requirements specific to HTTP/1.1.
 </t>
 <t>
+   Prohibited generation of bare CRs outside of payload body.
+   (<xref target="message.parsing"/>)
+</t>
+<t>
    In the ABNF for chunked extensions, re-introduced (bad) whitespace around
    ";" and "=". Whitespace was removed
    in <xref target="RFC7230"/>, but that change was found to break existing
@@ -3435,10 +3439,6 @@ Upgrade: websocket
    Disallowed transfer coding parameters called "q" in order to avoid
    conflicts with the use of ranks in the <x:ref>TE</x:ref> header field.
    (<xref target="transfer.coding.registry"/>)
-</t>
-<t>
-   Prohibited generation of bare CRs outside of payload body.
-   (<xref target="message.parsing"/>)
 </t>
 </section>
 </section>

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -316,6 +316,12 @@
    single LF as a line terminator and ignore any preceding CR.
 </t>
 <t>
+  One or more CR characters not succeeded by LF are "bare CRs", and
+  &MUST-NOT; be generated; recipients &MUST; either reject a field section
+  containing bare CRs, or convert them to SP before processing or forwarding
+  the message.
+</t>
+<t>
    Older HTTP/1.0 user agent implementations might send an extra CRLF
    after a POST request as a workaround for some early server
    applications that failed to read message body content that was
@@ -3416,6 +3422,10 @@ Upgrade: websocket
    conflicts with the use of ranks in the <x:ref>TE</x:ref> header field.
    (<xref target="transfer.coding.registry"/>)
 </t>
+<t>
+   Prohibited the generation of bare CRs in field sections.
+   (<xref target="message.parsing"/>)
+</t>
 </section>
 </section>
 
@@ -3519,6 +3529,7 @@ Upgrade: websocket
    <li>Move TE: trailers into <xref target="Semantics"/> (<eref target="https://github.com/httpwg/http-core/issues/18"/>)</li>
    <li>In <xref target="message.body.length"/>, adjust requirements for handling multiple content-length values (<eref target="https://github.com/httpwg/http-core/issues/59"/>)</li>
    <li>Throughout, replace "effective request URI" with "target URI" (<eref target="https://github.com/httpwg/http-core/issues/259"/>)</li>
+   <li>In <xref target="message.parsing"/>, disallow bare CRs (<eref target="https://github.com/httpwg/http-core/issues/31"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1430,6 +1430,11 @@ deployed and not likely to be registered in a timely manner otherwise.</t>
    opaque data.
 </t>
 <t>
+  Field values containing one or more CR characters ("bare CRs") &MUST-NOT;
+  be generated; recipients &MUST; either reject a field value containing bare
+  CRs, or convert them to SP before processing or forwarding the message.
+</t>
+<t>
    Leading and trailing whitespace in raw field values is removed upon field
    parsing (<xref target="field.parsing"/>). Field definitions where leading or trailing
    whitespace in values is significant will have to use a container syntax such
@@ -12313,6 +12318,10 @@ Content-Encoding: gzip
   <xref target="RFC7694"/>.
   (<xref target="request.conneg"/>)
 </t>
+<t>
+   Prohibited the generation of bare CRs in field values.
+   (<xref target="field.values"/>)
+</t>
 </section>
 
 <section title="Changes from RFC 7232" anchor="changes.from.rfc.7232">
@@ -12533,6 +12542,7 @@ Content-Encoding: gzip
   <li>In <xref target="field.if-unmodified-since"/>, refine requirements so that they don't apply to resources without a concept of modification time (<eref target="https://github.com/httpwg/http-core/issues/326"/>)</li>
   <li>In <xref target="field.proxy-authenticate"/>, specify the scope as a request, not a target resource (<eref target="https://github.com/httpwg/http-core/issues/331"/>)</li>
   <li>In <xref target="operation"/>, introduce concept of "complete" messages (<eref target="https://github.com/httpwg/http-core/issues/334"/>)</li>
+  <li>In <xref target="field.values"/>, disallow bare CRs (<eref target="https://github.com/httpwg/http-core/issues/31"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1431,12 +1431,6 @@ deployed and not likely to be registered in a timely manner otherwise.</t>
    opaque data.
 </t>
 <t>
-   A sender &MUST-NOT; generate a bare CR (a CR character not immediately
-   followed by LF) within a field value. A recipient of such a bare CR
-   &MUST; either consider that field value to be invalid or replace each bare
-   CR with SP before processing or forwarding the field.
-</t>
-<t>
    Leading and trailing whitespace in raw field values is removed upon field
    parsing (<xref target="field.parsing"/>). Field definitions where leading or trailing
    whitespace in values is significant will have to use a container syntax such
@@ -12338,10 +12332,6 @@ Content-Encoding: gzip
   <xref target="RFC7694"/>.
   (<xref target="request.conneg"/>)
 </t>
-<t>
-   Prohibited the generation of bare CRs in field values.
-   (<xref target="field.values"/>)
-</t>
 </section>
 
 <section title="Changes from RFC 7232" anchor="changes.from.rfc.7232">
@@ -12569,7 +12559,6 @@ Content-Encoding: gzip
 
 <section title="Since draft-ietf-httpbis-semantics-08" anchor="changes.since.08">
 <ul x:when-empty="None yet.">
-  <li>In <xref target="field.values"/>, disallow bare CRs (<eref target="https://github.com/httpwg/http-core/issues/31"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
changes to -messaging pulled from https://github.com/httpwg/http-core/pull/373