### PR TITLE
Clarify Range request on a zero-length representation

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12611,6 +12611,8 @@ Content-Encoding: gzip
 
 <section title="Since draft-ietf-httpbis-semantics-08" anchor="changes.since.08">
 <ul x:when-empty="None yet.">
+  <li>In <xref target="status.416"/>, remove duplicate definition of what makes a range satisfiable and refer instead to each range unit's definition (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
+  <li>In <xref target="byte.ranges"/> and <xref target="field.range"/>, clarify that a selected representation of zero length can only be satisfiable as a suffix range and that a server can still ignore Range for that case (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
   <li>In <xref target="field.accept"/> and <xref target="status.415"/>, allow "Accept" as response field (<eref target="https://github.com/httpwg/http-core/issues/48"/>)</li>
   <li><xref target="collected.abnf"/> now uses the sender variant of the "#" list expansion (<eref target="https://github.com/httpwg/http-core/issues/192"/>)</li>
   <li>In <xref target="field.name.registry"/>, add optional "Comments" entry (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
@@ -12618,8 +12620,6 @@ Content-Encoding: gzip
   <li>In <xref target="field.values"/>, update note about field ABNF  (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, include status 308 in list of heuristically cacheable status codes (<eref target="https://github.com/httpwg/http-core/issues/385"/>)</li>
   <li>In <xref target="field.content-encoding"/>, make it clearer that "identity" is not to be included (<eref target="https://github.com/httpwg/http-core/issues/388"/>)</li>
-  <li>In <xref target="status.416"/>, remove duplicate definition of what makes a range satisfiable and refer instead to each range unit's definition (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
-  <li>In <xref target="byte.ranges"/> and <xref target="field.range"/>, clarify that a selected representation of zero length can only be satisfiable as a suffix range and that a server can still ignore Range for that case (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -3313,8 +3313,8 @@ bytes=500-999
    is one less than the current length of the selected representation).
 </t>
 <t>
-   A client can request the last N bytes of the selected representation using
-   a <x:ref>suffix-range</x:ref>.
+   A client can request the last N bytes (N &gt; 0) of the selected
+   representation using a <x:ref>suffix-range</x:ref>.
    If the selected representation is shorter than the specified
    <x:ref>suffix-length</x:ref>, the entire representation is used.
 </t>
@@ -3353,9 +3353,14 @@ bytes=500-700,601-999
    If a valid bytes <x:ref>range-set</x:ref> includes at least one
    <x:ref>range-spec</x:ref> with a <x:ref>first-pos</x:ref> that is
    less than the current length of the representation, or at least one
-   <x:ref>suffix-range</x:ref> with a non-zero
-   <x:ref>suffix-length</x:ref>, then the bytes <x:ref>range-set</x:ref> is
-   satisfiable. Otherwise, the bytes <x:ref>range-set</x:ref> is unsatisfiable.
+   <x:ref>suffix-range</x:ref> with a non-zero <x:ref>suffix-length</x:ref>,
+   then the bytes <x:ref>range-set</x:ref> is satisfiable. Otherwise,
+   the bytes <x:ref>range-set</x:ref> is unsatisfiable.
+</t>
+<t>
+   If the selected representation has zero length, the only satisfiable form of
+   <x:ref>range-spec</x:ref> is a <x:ref>suffix-range</x:ref> with a non-zero
+   <x:ref>suffix-length</x:ref>.
 </t>
 <t>
    In the byte-range syntax, <x:ref>first-pos</x:ref>,
@@ -6149,6 +6154,11 @@ Expect: 100-continue
    same data.
 </t>
 <t>
+   A server that supports range requests &MAY; ignore a <x:ref>Range</x:ref>
+   header field when the selected representation has no body
+   (i.e., the selected representation data is of zero length).
+</t>
+<t>
    A client that is requesting multiple ranges &SHOULD; list those ranges in
    ascending order (the order in which they would typically be received in a
    complete representation) unless there is a specific need to request a later
@@ -8698,16 +8708,18 @@ Content-Range: bytes 7000-7999/8000
   <x:anchor-alias value="416 (Range Not Satisfiable)"/>
 <t>
    The <x:dfn>416 (Range Not Satisfiable)</x:dfn> status code indicates that
-   none of the ranges in the request's <x:ref>Range</x:ref> header field
-   (<xref target="field.range"/>) overlap the current extent of the
-   <x:ref>selected representation</x:ref> or that the set of ranges requested
-   has been rejected due to
-   invalid ranges or an excessive request of small or overlapping ranges.
+   the set of ranges in the request's <x:ref>Range</x:ref> header field
+   (<xref target="field.range"/>) has been rejected either because none of
+   the requested ranges are satisfiable or because the client has requested
+   an excessive number of small or overlapping ranges (a potential denial of
+   service attack).
 </t>
 <t>
-   For byte ranges, failing to overlap the current extent means that the
-   <x:ref>first-pos</x:ref> of all of the <x:ref>range-spec</x:ref>
-   values were greater than or equal to the current length of the selected representation.
+   Each range unit defines what is required for its own range sets to be
+   satisfiable. For example, <xref target="byte.ranges"/> defines what makes
+   a bytes range set satisfiable.
+</t>
+<t>
    When this status code is generated in response to a byte-range request, the
    sender &SHOULD; generate a <x:ref>Content-Range</x:ref> header field
    specifying the current length of the selected representation
@@ -8724,7 +8736,7 @@ Content-Range: bytes */47022
 <aside>
   <t>
     &Note; Because servers are free to ignore <x:ref>Range</x:ref>, many
-    implementations will simply respond with the entire selected representation
+    implementations will respond with the entire selected representation
     in a <x:ref>200 (OK)</x:ref> response. That is partly because
     most clients are prepared to receive a <x:ref>200 (OK)</x:ref> to
     complete the task (albeit less efficiently) and partly because clients
@@ -12606,6 +12618,8 @@ Content-Encoding: gzip
   <li>In <xref target="field.values"/>, update note about field ABNF  (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, include status 308 in list of heuristically cacheable status codes (<eref target="https://github.com/httpwg/http-core/issues/385"/>)</li>
   <li>In <xref target="field.content-encoding"/>, make it clearer that "identity" is not to be included (<eref target="https://github.com/httpwg/http-core/issues/388"/>)</li>
+  <li>In <xref target="status.416"/>, remove duplicate definition of what makes a range satisfiable and refer instead to each range unit's definition (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
+  <li>In <xref target="byte.ranges"/> and <xref target="field.range"/>, clarify that a selected representation of zero length can only be satisfiable as a suffix range and that a server can still ignore Range for that case (<eref target="https://github.com/httpwg/http-core/issues/12"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
In 416 status code section, remove duplicate definition of what makes a range satisfiable and refer instead to each range unit's definition. In sections on bytes ranges and Range, clarify that a selected representation of zero length can only be satisfiable as a suffix range and that a server can still ignore Range for that case.

Fixes #12