### PR TITLE
State that multiple "*" has no defined semantics

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5786,6 +5786,12 @@ Expect: 100-continue
    The If-Match header field can be ignored by caches and intermediaries
    because it is not applicable to a stored response.
 </t>
+<t>
+   Note that an If-Match header field with a list value containing "*" and
+   other values (including other instances of "*") does not have defined
+   semantics, and such field values are not interoperable. This is a consequence
+   of the field being specified as a choice between a single and multiple values.
+</t>
 </section>
 
 <section title="If-None-Match" anchor="field.if-none-match">
@@ -5867,6 +5873,12 @@ Expect: 100-continue
 <t>
    Requirements on cache handling of a received If-None-Match header field
    are defined in <xref target="validation.received"/>.
+</t>
+<t>
+   Note that an If-None-Match header field with a list value containing "*" and
+   other values (including other instances of "*") does not have defined
+   semantics, and such field values are not interoperable. This is a consequence
+   of the field being specified as a choice between a single and multiple values.
 </t>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5874,9 +5874,7 @@ Expect: 100-continue
 </t>
 <t>
    Note that an If-None-Match header field with a list value containing "*" and
-   other values (including other instances of "*") does not have defined
-   semantics, and such field values are not interoperable. This is a consequence
-   of the field being specified as a choice between a single and multiple values.
+   other values (including other instances of "*") is unlikely to be interoperable.
 </t>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12614,11 +12614,11 @@ Content-Encoding: gzip
   <li>In <xref target="field.accept"/> and <xref target="status.415"/>, allow "Accept" as response field (<eref target="https://github.com/httpwg/http-core/issues/48"/>)</li>
   <li><xref target="collected.abnf"/> now uses the sender variant of the "#" list expansion (<eref target="https://github.com/httpwg/http-core/issues/192"/>)</li>
   <li>In <xref target="field.name.registry"/>, add optional "Comments" entry (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
+  <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" has no defined semantics (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
   <li>In <xref target="field.values"/>, instruct recipients how to deal with control characters in field values (<eref target="https://github.com/httpwg/http-core/issues/377"/>)</li>
   <li>In <xref target="field.values"/>, update note about field ABNF  (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, include status 308 in list of heuristically cacheable status codes (<eref target="https://github.com/httpwg/http-core/issues/385"/>)</li>
   <li>In <xref target="field.content-encoding"/>, make it clearer that "identity" is not to be included (<eref target="https://github.com/httpwg/http-core/issues/388"/>)</li>
-  <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" has no defined semantics (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5788,9 +5788,7 @@ Expect: 100-continue
 </t>
 <t>
    Note that an If-Match header field with a list value containing "*" and
-   other values (including other instances of "*") does not have defined
-   semantics, and such field values are not interoperable. This is a consequence
-   of the field being specified as a choice between a single and multiple values.
+   other values (including other instances of "*") is unlikely to be interoperable.
 </t>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12618,6 +12618,7 @@ Content-Encoding: gzip
   <li>In <xref target="field.values"/>, update note about field ABNF  (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, include status 308 in list of heuristically cacheable status codes (<eref target="https://github.com/httpwg/http-core/issues/385"/>)</li>
   <li>In <xref target="field.content-encoding"/>, make it clearer that "identity" is not to be included (<eref target="https://github.com/httpwg/http-core/issues/388"/>)</li>
+  <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" has no defined semantics (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12610,7 +12610,7 @@ Content-Encoding: gzip
   <li>In <xref target="field.accept"/> and <xref target="status.415"/>, allow "Accept" as response field (<eref target="https://github.com/httpwg/http-core/issues/48"/>)</li>
   <li><xref target="collected.abnf"/> now uses the sender variant of the "#" list expansion (<eref target="https://github.com/httpwg/http-core/issues/192"/>)</li>
   <li>In <xref target="field.name.registry"/>, add optional "Comments" entry (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
-  <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" has no defined semantics (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
+  <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" is unlikely to be interoperable (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
   <li>In <xref target="field.values"/>, instruct recipients how to deal with control characters in field values (<eref target="https://github.com/httpwg/http-core/issues/377"/>)</li>
   <li>In <xref target="field.values"/>, update note about field ABNF  (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, include status 308 in list of heuristically cacheable status codes (<eref target="https://github.com/httpwg/http-core/issues/385"/>)</li>


### PR DESCRIPTION
... for If-Match and If-None-Match.


Fixes #305.