### PR TITLE
Avoid use of obsolete media type parameter on text/html (#375)

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6562,8 +6562,8 @@ Expect: 100-continue
    that matches the type. For example,
 </t>
 <artwork type="example">
-  Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,
-          text/html;level=2;q=0.4, */*;q=0.5
+  Accept: text/*;q=0.3, text/plain;q=0.7, text/plain;format=flowed,
+          text/plain;format=fixed;q=0.4, */*;q=0.5
 </artwork>
 <t>
    would cause the following values to be associated:
@@ -6577,15 +6577,15 @@ Expect: 100-continue
   </thead>
   <tbody>
     <tr>
-      <td>text/html;level=1</td>
+      <td>text/plain;format=flowed</td>
       <td>1</td>
     </tr>
     <tr>
-      <td>text/html</td>
+      <td>text/plain</td>
       <td>0.7</td>
     </tr>
     <tr>
-      <td>text/plain</td>
+      <td>text/html</td>
       <td>0.3</td>
     </tr>
     <tr>
@@ -6593,7 +6593,7 @@ Expect: 100-continue
       <td>0.5</td>
     </tr>
     <tr>
-      <td>text/html;level=2</td>
+      <td>text/plain;format=fixed</td>
       <td>0.4</td>
     </tr>
     <tr>
@@ -12694,6 +12694,7 @@ Content-Encoding: gzip
   <li>In <xref target="field.vary"/>, make the field list-based even when "*" is present (<eref target="https://github.com/httpwg/http-core/issues/272"/>)</li>
   <li>In <xref target="field.name.registry"/>, add optional "Comments" entry (<eref target="https://github.com/httpwg/http-core/issues/273"/>)</li>
   <li>In <xref target="field.if-match"/> and <xref target="field.if-none-match"/>, state that multiple "*" is unlikely to be interoperable (<eref target="https://github.com/httpwg/http-core/issues/305"/>)</li>
+  <li>In <xref target="field.accept"/>, avoid use of obsolete media type parameter on text/html (<eref target="https://github.com/httpwg/http-core/issues/375"/>)</li>
   <li>In <xref target="field.values"/>, instruct recipients how to deal with control characters in field values (<eref target="https://github.com/httpwg/http-core/issues/377"/>)</li>
   <li>In <xref target="field.values"/>, update note about field ABNF (<eref target="https://github.com/httpwg/http-core/issues/380"/>)</li>
   <li>Add <xref target="extending.versioning"/> about Extending and Versioning HTTP (<eref target="https://github.com/httpwg/http-core/issues/384"/>)</li>


### PR DESCRIPTION
Note that I decided to switch to text/plain (and format parameter), for consistency with the preceding text in that section.