### PR TITLE
make section xrefs in tables more concise and consistent (editorial)

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -256,55 +256,55 @@
     <tr>
       <th>Title</th>
       <th>Reference</th>
-      <th>Changes</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>HTTP Over TLS</td>
       <td><xref target="RFC2818"/></td>
-      <td><xref target="changes.from.rfc.2818"/></td>
+      <td><xref target="changes.from.rfc.2818" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP/1.1 Message Syntax and Routing [*]</td>
       <td><xref target="RFC7230"/></td>
-      <td><xref target="changes.from.rfc.7230"/></td>
+      <td><xref target="changes.from.rfc.7230" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP/1.1 Semantics and Content</td>
       <td><xref target="RFC7231"/></td>
-      <td><xref target="changes.from.rfc.7231"/></td>
+      <td><xref target="changes.from.rfc.7231" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP/1.1 Conditional Requests</td>
       <td><xref target="RFC7232"/></td>
-      <td><xref target="changes.from.rfc.7232"/></td>
+      <td><xref target="changes.from.rfc.7232" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP/1.1 Range Requests</td>
       <td><xref target="RFC7233"/></td>
-      <td><xref target="changes.from.rfc.7233"/></td>
+      <td><xref target="changes.from.rfc.7233" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP/1.1 Authentication</td>
       <td><xref target="RFC7235"/></td>
-      <td><xref target="changes.from.rfc.7235"/></td>
+      <td><xref target="changes.from.rfc.7235" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP Status Code 308 (Permanent Redirect)</td>
       <td><xref target="RFC7538"/></td>
-      <td><xref target="changes.from.rfc.7538"/></td>
+      <td><xref target="changes.from.rfc.7538" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP Authentication-Info and Proxy-Authentication-Info
           Response Header Fields</td>
       <td><xref target="RFC7615"/></td>
-      <td><xref target="changes.from.rfc.7615"/></td>
+      <td><xref target="changes.from.rfc.7615" format="counter"/></td>
     </tr>
     <tr>
       <td>HTTP Client-Initiated Content-Encoding</td>
       <td><xref target="RFC7694"/></td>
-      <td><xref target="changes.from.rfc.7694"/></td>
+      <td><xref target="changes.from.rfc.7694" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -842,19 +842,19 @@ Content-Type: text/plain
     <tr>
       <th>URI Scheme</th>
       <th>Description</th>
-      <th>Reference</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>http</td>
       <td>Hypertext Transfer Protocol</td>
-      <td><xref target="http.uri"/></td>
+      <td><xref target="http.uri" format="counter"/></td>
     </tr>
     <tr>
       <td>https</td>
       <td>Hypertext Transfer Protocol Secure</td>
-      <td><xref target="https.uri"/></td>
+      <td><xref target="https.uri" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -2171,7 +2171,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
       <tr>
          <th>Field Name</th>
          <th>Status</th>
-         <th>Reference</th>
+         <th>See</th>
       </tr>
    </thead>
    <tbody>
@@ -2179,287 +2179,287 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
          <td>Accept</td>
          <td>standard</td>
          <td>
-            <xref target="field.accept"/>
+            <xref target="field.accept" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Accept-Charset</td>
          <td>deprecated</td>
          <td>
-            <xref target="field.accept-charset"/>
+            <xref target="field.accept-charset" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Accept-Encoding</td>
          <td>standard</td>
          <td>
-            <xref target="field.accept-encoding"/>
+            <xref target="field.accept-encoding" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Accept-Language</td>
          <td>standard</td>
          <td>
-            <xref target="field.accept-language"/>
+            <xref target="field.accept-language" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Accept-Ranges</td>
          <td>standard</td>
          <td>
-            <xref target="field.accept-ranges"/>
+            <xref target="field.accept-ranges" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Allow</td>
          <td>standard</td>
          <td>
-            <xref target="field.allow"/>
+            <xref target="field.allow" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Authentication-Info</td>
          <td>standard</td>
          <td>
-            <xref target="field.authentication-info"/>
+            <xref target="field.authentication-info" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Authorization</td>
          <td>standard</td>
          <td>
-            <xref target="field.authorization"/>
+            <xref target="field.authorization" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Encoding</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-encoding"/>
+            <xref target="field.content-encoding" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Language</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-language"/>
+            <xref target="field.content-language" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Length</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-length"/>
+            <xref target="field.content-length" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Location</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-location"/>
+            <xref target="field.content-location" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Range</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-range"/>
+            <xref target="field.content-range" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Content-Type</td>
          <td>standard</td>
          <td>
-            <xref target="field.content-type"/>
+            <xref target="field.content-type" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Date</td>
          <td>standard</td>
          <td>
-            <xref target="field.date"/>
+            <xref target="field.date" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>ETag</td>
          <td>standard</td>
          <td>
-            <xref target="field.etag"/>
+            <xref target="field.etag" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Expect</td>
          <td>standard</td>
          <td>
-            <xref target="field.expect"/>
+            <xref target="field.expect" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>From</td>
          <td>standard</td>
          <td>
-            <xref target="field.from"/>
+            <xref target="field.from" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Host</td>
          <td>standard</td>
          <td>
-            <xref target="field.host"/>
+            <xref target="field.host" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>If-Match</td>
          <td>standard</td>
          <td>
-            <xref target="field.if-match"/>
+            <xref target="field.if-match" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>If-Modified-Since</td>
          <td>standard</td>
          <td>
-            <xref target="field.if-modified-since"/>
+            <xref target="field.if-modified-since" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>If-None-Match</td>
          <td>standard</td>
          <td>
-            <xref target="field.if-none-match"/>
+            <xref target="field.if-none-match" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>If-Range</td>
          <td>standard</td>
          <td>
-            <xref target="field.if-range"/>
+            <xref target="field.if-range" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>If-Unmodified-Since</td>
          <td>standard</td>
          <td>
-            <xref target="field.if-unmodified-since"/>
+            <xref target="field.if-unmodified-since" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Last-Modified</td>
          <td>standard</td>
          <td>
-            <xref target="field.last-modified"/>
+            <xref target="field.last-modified" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Location</td>
          <td>standard</td>
          <td>
-            <xref target="field.location"/>
+            <xref target="field.location" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Max-Forwards</td>
          <td>standard</td>
          <td>
-            <xref target="field.max-forwards"/>
+            <xref target="field.max-forwards" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Proxy-Authenticate</td>
          <td>standard</td>
          <td>
-            <xref target="field.proxy-authenticate"/>
+            <xref target="field.proxy-authenticate" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Proxy-Authentication-Info</td>
          <td>standard</td>
          <td>
-            <xref target="field.proxy-authentication-info"/>
+            <xref target="field.proxy-authentication-info" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Proxy-Authorization</td>
          <td>standard</td>
          <td>
-            <xref target="field.proxy-authorization"/>
+            <xref target="field.proxy-authorization" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Range</td>
          <td>standard</td>
          <td>
-            <xref target="field.range"/>
+            <xref target="field.range" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Referer</td>
          <td>standard</td>
          <td>
-            <xref target="field.referer"/>
+            <xref target="field.referer" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Retry-After</td>
          <td>standard</td>
          <td>
-            <xref target="field.retry-after"/>
+            <xref target="field.retry-after" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Server</td>
          <td>standard</td>
          <td>
-            <xref target="field.server"/>
+            <xref target="field.server" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>TE</td>
          <td>standard</td>
          <td>
-            <xref target="field.te"/>
+            <xref target="field.te" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Trailer</td>
          <td>standard</td>
          <td>
-            <xref target="field.trailer"/>
+            <xref target="field.trailer" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Upgrade</td>
          <td>standard</td>
          <td>
-            <xref target="field.upgrade"/>
+            <xref target="field.upgrade" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>User-Agent</td>
          <td>standard</td>
          <td>
-            <xref target="field.user-agent"/>
+            <xref target="field.user-agent" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Vary</td>
          <td>standard</td>
          <td>
-            <xref target="field.vary"/>
+            <xref target="field.vary" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>Via</td>
          <td>standard</td>
          <td>
-            <xref target="field.via"/>
+            <xref target="field.via" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>WWW-Authenticate</td>
          <td>standard</td>
          <td>
-            <xref target="field.www-authenticate"/>
+            <xref target="field.www-authenticate" format="counter"/>
          </td>
       </tr>
    </tbody>
@@ -2476,7 +2476,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
     <tr>
      <th>Field Name</th>
      <th>Status</th>
-     <th>Reference</th>
+     <th>See</th>
      <th>Comments</th>
     </tr>
   </thead>
@@ -2485,7 +2485,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
       <td>*</td>
       <td>standard</td>
       <td>
-        <xref target="field.definitions"/>
+        <xref target="field.definitions" format="counter"/>
       </td>
       <td>
         (reserved)
@@ -3265,7 +3265,7 @@ Upgrade: websocket
       <th>Name</th>
       <th>Description</th>
       <th>Expected Version Tokens</th>
-      <th>Reference</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
@@ -3273,7 +3273,7 @@ Upgrade: websocket
       <td>HTTP</td>
       <td>Hypertext Transfer Protocol</td>
       <td>any DIGIT.DIGIT (e.g, "2.0")</td>
-      <td><xref target="protocol.version"/></td>
+      <td><xref target="protocol.version" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -3537,40 +3537,40 @@ Upgrade: websocket
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>Reference</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>compress</td>
       <td>UNIX "compress" data format <xref target="Welch"/></td>
-      <td><xref target="compress.coding"/></td>
+      <td><xref target="compress.coding" format="counter"/></td>
     </tr>
     <tr>
       <td>deflate</td>
       <td>"deflate" compressed data (<xref target="RFC1951"/>) inside
       the "zlib" data format (<xref target="RFC1950"/>)</td>
-      <td><xref target="deflate.coding"/></td>
+      <td><xref target="deflate.coding" format="counter"/></td>
     </tr>
     <tr>
       <td>gzip</td>
       <td>GZIP file format <xref target="RFC1952"/></td>
-      <td><xref target="gzip.coding"/></td>
+      <td><xref target="gzip.coding" format="counter"/></td>
     </tr>
     <tr>
       <td>identity</td>
       <td>Reserved</td>
-      <td><xref target="field.accept-encoding"/></td>
+      <td><xref target="field.accept-encoding" format="counter"/></td>
     </tr>
     <tr>
       <td>x-compress</td>
       <td>Deprecated (alias for compress)</td>
-      <td><xref target="compress.coding"/></td>
+      <td><xref target="compress.coding" format="counter"/></td>
     </tr>
     <tr>
       <td>x-gzip</td>
       <td>Deprecated (alias for gzip)</td>
-      <td><xref target="gzip.coding"/></td>
+      <td><xref target="gzip.coding" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -3713,19 +3713,19 @@ Upgrade: websocket
     <tr>
       <th>Range Unit Name</th>
       <th>Description</th>
-      <th>Reference</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>bytes</td>
       <td>a range of octets</td>
-      <td><xref target="byte.ranges"/></td>
+      <td><xref target="byte.ranges" format="counter"/></td>
     </tr>
     <tr>
       <td>none</td>
       <td>reserved as keyword to indicate range requests are not supported</td>
-      <td><xref target="field.accept-ranges"/></td>
+      <td><xref target="field.accept-ranges" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -3958,29 +3958,29 @@ bytes=500-700,601-999
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Content-Type</td>
-      <td><xref target="field.content-type"/></td>
+      <td><xref target="field.content-type" format="counter"/></td>
     </tr>
     <tr>
       <td>Content-Encoding</td>
-      <td><xref target="field.content-encoding"/></td>
+      <td><xref target="field.content-encoding" format="counter"/></td>
     </tr>
     <tr>
       <td>Content-Language</td>
-      <td><xref target="field.content-language"/></td>
+      <td><xref target="field.content-language" format="counter"/></td>
     </tr>
     <tr>
       <td>Content-Length</td>
-      <td><xref target="field.content-length"/></td>
+      <td><xref target="field.content-length" format="counter"/></td>
     </tr>
     <tr>
       <td>Content-Location</td>
-      <td><xref target="field.content-location"/></td>
+      <td><xref target="field.content-location" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -4344,21 +4344,21 @@ bytes=500-700,601-999
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Content-Range</td>
-      <td><xref target="field.content-range"/></td>
+      <td><xref target="field.content-range" format="counter"/></td>
     </tr>
     <tr>
       <td>Trailer</td>
-      <td><xref target="field.trailer"/></td>
+      <td><xref target="field.trailer" format="counter"/></td>
     </tr>
     <tr>
       <td>Transfer-Encoding</td>
-      <td><xref target="field.transfer-encoding"/></td>
+      <td><xref target="field.transfer-encoding" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -4947,7 +4947,7 @@ Content-Range: exampleunit 11.2-14.3/25
     <tr>
       <th>Method</th>
       <th>Description</th>
-      <th>Sec.</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
@@ -5020,7 +5020,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <th>Method</th>
          <th>Safe</th>
          <th>Idempotent</th>
-         <th>Reference</th>
+         <th>See</th>
       </tr>
    </thead>
    <tbody>
@@ -5029,7 +5029,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>no</td>
          <td>no</td>
          <td>
-            <xref target="CONNECT"/>
+            <xref target="CONNECT" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5037,7 +5037,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>no</td>
          <td>yes</td>
          <td>
-            <xref target="DELETE"/>
+            <xref target="DELETE" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5045,7 +5045,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>yes</td>
          <td>yes</td>
          <td>
-            <xref target="GET"/>
+            <xref target="GET" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5053,7 +5053,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>yes</td>
          <td>yes</td>
          <td>
-            <xref target="HEAD"/>
+            <xref target="HEAD" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5061,7 +5061,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>yes</td>
          <td>yes</td>
          <td>
-            <xref target="OPTIONS"/>
+            <xref target="OPTIONS" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5069,7 +5069,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>no</td>
          <td>no</td>
          <td>
-            <xref target="POST"/>
+            <xref target="POST" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5077,7 +5077,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>no</td>
          <td>yes</td>
          <td>
-            <xref target="PUT"/>
+            <xref target="PUT" format="counter"/>
          </td>
       </tr>
       <tr>
@@ -5085,7 +5085,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <td>yes</td>
          <td>yes</td>
          <td>
-            <xref target="TRACE"/>
+            <xref target="TRACE" format="counter"/>
          </td>
       </tr>
    </tbody>
@@ -5840,33 +5840,33 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Cache-Control</td>
-      <td><xref target="field.cache-control"/></td>
+      <td><xref target="field.cache-control" format="counter"/></td>
     </tr>
     <tr>
       <td>Expect</td>
-      <td><xref target="field.expect"/></td>
+      <td><xref target="field.expect" format="counter"/></td>
     </tr>
     <tr>
       <td>Host</td>
-      <td><xref target="field.host"/></td>
+      <td><xref target="field.host" format="counter"/></td>
     </tr>
     <tr>
       <td>Max-Forwards</td>
-      <td><xref target="field.max-forwards"/></td>
+      <td><xref target="field.max-forwards" format="counter"/></td>
     </tr>
     <tr>
       <td>Pragma</td>
-      <td><xref target="field.pragma"/></td>
+      <td><xref target="field.pragma" format="counter"/></td>
     </tr>
     <tr>
       <td>TE</td>
-      <td><xref target="field.te"/></td>
+      <td><xref target="field.te" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -6103,29 +6103,29 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>If-Match</td>
-      <td><xref target="field.if-match"/></td>
+      <td><xref target="field.if-match" format="counter"/></td>
     </tr>
     <tr>
       <td>If-None-Match</td>
-      <td><xref target="field.if-none-match"/></td>
+      <td><xref target="field.if-none-match" format="counter"/></td>
     </tr>
     <tr>
       <td>If-Modified-Since</td>
-      <td><xref target="field.if-modified-since"/></td>
+      <td><xref target="field.if-modified-since" format="counter"/></td>
     </tr>
     <tr>
       <td>If-Unmodified-Since</td>
-      <td><xref target="field.if-unmodified-since"/></td>
+      <td><xref target="field.if-unmodified-since" format="counter"/></td>
     </tr>
     <tr>
       <td>If-Range</td>
-      <td><xref target="field.if-range"/></td>
+      <td><xref target="field.if-range" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -6756,25 +6756,25 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Accept</td>
-      <td><xref target="field.accept"/></td>
+      <td><xref target="field.accept" format="counter"/></td>
     </tr>
     <tr>
       <td>Accept-Charset</td>
-      <td><xref target="field.accept-charset"/></td>
+      <td><xref target="field.accept-charset" format="counter"/></td>
     </tr>
     <tr>
       <td>Accept-Encoding</td>
-      <td><xref target="field.accept-encoding"/></td>
+      <td><xref target="field.accept-encoding" format="counter"/></td>
     </tr>
     <tr>
       <td>Accept-Language</td>
-      <td><xref target="field.accept-language"/></td>
+      <td><xref target="field.accept-language" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -7194,17 +7194,17 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Authorization</td>
-      <td><xref target="field.authorization"/></td>
+      <td><xref target="field.authorization" format="counter"/></td>
     </tr>
     <tr>
       <td>Proxy-Authorization</td>
-      <td><xref target="field.proxy-authorization"/></td>
+      <td><xref target="field.proxy-authorization" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -7554,21 +7554,21 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>From</td>
-      <td><xref target="field.from"/></td>
+      <td><xref target="field.from" format="counter"/></td>
     </tr>
     <tr>
       <td>Referer</td>
-      <td><xref target="field.referer"/></td>
+      <td><xref target="field.referer" format="counter"/></td>
     </tr>
     <tr>
       <td>User-Agent</td>
-      <td><xref target="field.user-agent"/></td>
+      <td><xref target="field.user-agent" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -7824,7 +7824,7 @@ Expect: 100-continue
       <tr>
          <th>Value</th>
          <th>Description</th>
-         <th>Reference</th>
+         <th>See</th>
       </tr>
    </thead>
    <tbody>
@@ -7832,315 +7832,315 @@ Expect: 100-continue
          <td>100</td>
          <td>Continue</td>
          <td>
-            <xref target="status.100"/>
+            <xref target="status.100" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>101</td>
          <td>Switching Protocols</td>
          <td>
-            <xref target="status.101"/>
+            <xref target="status.101" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>200</td>
          <td>OK</td>
          <td>
-            <xref target="status.200"/>
+            <xref target="status.200" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>201</td>
          <td>Created</td>
          <td>
-            <xref target="status.201"/>
+            <xref target="status.201" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>202</td>
          <td>Accepted</td>
          <td>
-            <xref target="status.202"/>
+            <xref target="status.202" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>203</td>
          <td>Non-Authoritative Information</td>
          <td>
-            <xref target="status.203"/>
+            <xref target="status.203" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>204</td>
          <td>No Content</td>
          <td>
-            <xref target="status.204"/>
+            <xref target="status.204" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>205</td>
          <td>Reset Content</td>
          <td>
-            <xref target="status.205"/>
+            <xref target="status.205" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>206</td>
          <td>Partial Content</td>
          <td>
-            <xref target="status.206"/>
+            <xref target="status.206" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>300</td>
          <td>Multiple Choices</td>
          <td>
-            <xref target="status.300"/>
+            <xref target="status.300" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>301</td>
          <td>Moved Permanently</td>
          <td>
-            <xref target="status.301"/>
+            <xref target="status.301" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>302</td>
          <td>Found</td>
          <td>
-            <xref target="status.302"/>
+            <xref target="status.302" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>303</td>
          <td>See Other</td>
          <td>
-            <xref target="status.303"/>
+            <xref target="status.303" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>304</td>
          <td>Not Modified</td>
          <td>
-            <xref target="status.304"/>
+            <xref target="status.304" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>305</td>
          <td>Use Proxy</td>
          <td>
-            <xref target="status.305"/>
+            <xref target="status.305" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>306</td>
          <td>(Unused)</td>
          <td>
-            <xref target="status.306"/>
+            <xref target="status.306" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>307</td>
          <td>Temporary Redirect</td>
          <td>
-            <xref target="status.307"/>
+            <xref target="status.307" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>308</td>
          <td>Permanent Redirect</td>
          <td>
-            <xref target="status.308"/>
+            <xref target="status.308" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>400</td>
          <td>Bad Request</td>
          <td>
-            <xref target="status.400"/>
+            <xref target="status.400" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>401</td>
          <td>Unauthorized</td>
          <td>
-            <xref target="status.401"/>
+            <xref target="status.401" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>402</td>
          <td>Payment Required</td>
          <td>
-            <xref target="status.402"/>
+            <xref target="status.402" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>403</td>
          <td>Forbidden</td>
          <td>
-            <xref target="status.403"/>
+            <xref target="status.403" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>404</td>
          <td>Not Found</td>
          <td>
-            <xref target="status.404"/>
+            <xref target="status.404" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>405</td>
          <td>Method Not Allowed</td>
          <td>
-            <xref target="status.405"/>
+            <xref target="status.405" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>406</td>
          <td>Not Acceptable</td>
          <td>
-            <xref target="status.406"/>
+            <xref target="status.406" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>407</td>
          <td>Proxy Authentication Required</td>
          <td>
-            <xref target="status.407"/>
+            <xref target="status.407" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>408</td>
          <td>Request Timeout</td>
          <td>
-            <xref target="status.408"/>
+            <xref target="status.408" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>409</td>
          <td>Conflict</td>
          <td>
-            <xref target="status.409"/>
+            <xref target="status.409" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>410</td>
          <td>Gone</td>
          <td>
-            <xref target="status.410"/>
+            <xref target="status.410" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>411</td>
          <td>Length Required</td>
          <td>
-            <xref target="status.411"/>
+            <xref target="status.411" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>412</td>
          <td>Precondition Failed</td>
          <td>
-            <xref target="status.412"/>
+            <xref target="status.412" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>413</td>
          <td>Payload Too Large</td>
          <td>
-            <xref target="status.413"/>
+            <xref target="status.413" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>414</td>
          <td>URI Too Long</td>
          <td>
-            <xref target="status.414"/>
+            <xref target="status.414" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>415</td>
          <td>Unsupported Media Type</td>
          <td>
-            <xref target="status.415"/>
+            <xref target="status.415" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>416</td>
          <td>Range Not Satisfiable</td>
          <td>
-            <xref target="status.416"/>
+            <xref target="status.416" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>417</td>
          <td>Expectation Failed</td>
          <td>
-            <xref target="status.417"/>
+            <xref target="status.417" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>418</td>
          <td>(Unused)</td>
          <td>
-            <xref target="status.418"/>
+            <xref target="status.418" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>422</td>
          <td>Unprocessable Payload</td>
          <td>
-            <xref target="status.422"/>
+            <xref target="status.422" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>426</td>
          <td>Upgrade Required</td>
          <td>
-            <xref target="status.426"/>
+            <xref target="status.426" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>500</td>
          <td>Internal Server Error</td>
          <td>
-            <xref target="status.500"/>
+            <xref target="status.500" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>501</td>
          <td>Not Implemented</td>
          <td>
-            <xref target="status.501"/>
+            <xref target="status.501" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>502</td>
          <td>Bad Gateway</td>
          <td>
-            <xref target="status.502"/>
+            <xref target="status.502" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>503</td>
          <td>Service Unavailable</td>
          <td>
-            <xref target="status.503"/>
+            <xref target="status.503" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>504</td>
          <td>Gateway Timeout</td>
          <td>
-            <xref target="status.504"/>
+            <xref target="status.504" format="counter"/>
          </td>
       </tr>
       <tr>
          <td>505</td>
          <td>HTTP Version Not Supported</td>
          <td>
-            <xref target="status.505"/>
+            <xref target="status.505" format="counter"/>
          </td>
       </tr>
    </tbody>
@@ -9570,41 +9570,41 @@ Content-Type: text/plain
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Age</td>
-      <td><xref target="field.age"/></td>
+      <td><xref target="field.age" format="counter"/></td>
     </tr>
     <tr>
       <td>Cache-Control</td>
-      <td><xref target="field.cache-control"/></td>
+      <td><xref target="field.cache-control" format="counter"/></td>
     </tr>
     <tr>
       <td>Expires</td>
-      <td><xref target="field.expires"/></td>
+      <td><xref target="field.expires" format="counter"/></td>
     </tr>
     <tr>
       <td>Date</td>
-      <td><xref target="field.date"/></td>
+      <td><xref target="field.date" format="counter"/></td>
     </tr>
     <tr>
       <td>Location</td>
-      <td><xref target="field.location"/></td>
+      <td><xref target="field.location" format="counter"/></td>
     </tr>
     <tr>
       <td>Retry-After</td>
-      <td><xref target="field.retry-after"/></td>
+      <td><xref target="field.retry-after" format="counter"/></td>
     </tr>
     <tr>
       <td>Vary</td>
-      <td><xref target="field.vary"/></td>
+      <td><xref target="field.vary" format="counter"/></td>
     </tr>
     <tr>
       <td>Warning</td>
-      <td><xref target="field.warning"/></td>
+      <td><xref target="field.warning" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -9886,17 +9886,17 @@ Content-Type: text/plain
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>ETag</td>
-      <td><xref target="field.etag"/></td>
+      <td><xref target="field.etag" format="counter"/></td>
     </tr>
     <tr>
       <td>Last-Modified</td>
-      <td><xref target="field.last-modified"/></td>
+      <td><xref target="field.last-modified" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -10387,17 +10387,17 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>WWW-Authenticate</td>
-      <td><xref target="field.www-authenticate"/></td>
+      <td><xref target="field.www-authenticate" format="counter"/></td>
     </tr>
     <tr>
       <td>Proxy-Authenticate</td>
-      <td><xref target="field.proxy-authenticate"/></td>
+      <td><xref target="field.proxy-authenticate" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -10411,17 +10411,17 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Authentication-Info</td>
-      <td><xref target="field.authentication-info"/></td>
+      <td><xref target="field.authentication-info" format="counter"/></td>
     </tr>
     <tr>
       <td>Proxy-Authentication-Info</td>
-      <td><xref target="field.proxy-authentication-info"/></td>
+      <td><xref target="field.proxy-authentication-info" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -10608,21 +10608,21 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>Defined in...</th>
+      <th>See</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Accept-Ranges</td>
-      <td><xref target="field.accept-ranges"/></td>
+      <td><xref target="field.accept-ranges" format="counter"/></td>
     </tr>
     <tr>
       <td>Allow</td>
-      <td><xref target="field.allow"/></td>
+      <td><xref target="field.allow" format="counter"/></td>
     </tr>
     <tr>
       <td>Server</td>
-      <td><xref target="field.server"/></td>
+      <td><xref target="field.server" format="counter"/></td>
     </tr>
   </tbody>
 </table>
@@ -12888,13 +12888,13 @@ transfer-coding = &lt;transfer-coding, see <xref target="Messaging" x:fmt="," x:
    None yet.
 </t>
 </section>
-</section>
 
 <section title="Changes from RFC 7694" anchor="changes.from.rfc.7694">
 <t>
    This specification includes the extension defined in <xref target="RFC7694"/>,
    but leaves out examples and deployment considerations.
 </t>
+</section>
 </section>
 
 <section title="Change Log" anchor="change.log" removeInRFC="true">

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -256,7 +256,7 @@
     <tr>
       <th>Title</th>
       <th>Reference</th>
-      <th>See</th>
+      <th>Changes</th>
     </tr>
   </thead>
   <tbody>
@@ -842,7 +842,7 @@ Content-Type: text/plain
     <tr>
       <th>URI Scheme</th>
       <th>Description</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -2171,7 +2171,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
       <tr>
          <th>Field Name</th>
          <th>Status</th>
-         <th>See</th>
+         <th>Ref.</th>
       </tr>
    </thead>
    <tbody>
@@ -2476,7 +2476,7 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
     <tr>
      <th>Field Name</th>
      <th>Status</th>
-     <th>See</th>
+     <th>Ref.</th>
      <th>Comments</th>
     </tr>
   </thead>
@@ -3265,7 +3265,7 @@ Upgrade: websocket
       <th>Name</th>
       <th>Description</th>
       <th>Expected Version Tokens</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -3537,7 +3537,7 @@ Upgrade: websocket
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -3713,7 +3713,7 @@ Upgrade: websocket
     <tr>
       <th>Range Unit Name</th>
       <th>Description</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -3958,7 +3958,7 @@ bytes=500-700,601-999
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -4344,7 +4344,7 @@ bytes=500-700,601-999
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -4947,7 +4947,7 @@ Content-Range: exampleunit 11.2-14.3/25
     <tr>
       <th>Method</th>
       <th>Description</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -5020,7 +5020,7 @@ Content-Range: exampleunit 11.2-14.3/25
          <th>Method</th>
          <th>Safe</th>
          <th>Idempotent</th>
-         <th>See</th>
+         <th>Ref.</th>
       </tr>
    </thead>
    <tbody>
@@ -5840,7 +5840,7 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -6103,7 +6103,7 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -6756,7 +6756,7 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -7194,7 +7194,7 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -7554,7 +7554,7 @@ Expect: 100-continue
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -7824,7 +7824,7 @@ Expect: 100-continue
       <tr>
          <th>Value</th>
          <th>Description</th>
-         <th>See</th>
+         <th>Ref.</th>
       </tr>
    </thead>
    <tbody>
@@ -9570,7 +9570,7 @@ Content-Type: text/plain
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -9886,7 +9886,7 @@ Content-Type: text/plain
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -10387,7 +10387,7 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -10411,7 +10411,7 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>
@@ -10608,7 +10608,7 @@ Content-Encoding: gzip
   <thead>
     <tr>
       <th>Field Name</th>
-      <th>See</th>
+      <th>Ref.</th>
     </tr>
   </thead>
   <tbody>

--- a/lib/extract-header-defs.xslt
+++ b/lib/extract-header-defs.xslt
@@ -18,7 +18,7 @@
         <tr>
           <th>Field Name</th>
           <th>Status</th>
-          <th>Reference</th>
+          <th>See</th>
         </tr>
       </thead>
       <xsl:text>&#10;</xsl:text>
@@ -98,7 +98,7 @@
   <tr>
     <td><xsl:value-of select="$t"/></td>
     <td><xsl:value-of select="$status"/></td>
-    <td><xref target="{@anchor}"/></td>
+    <td><xref target="{@anchor}" format="counter"/></td>
   </tr>  
 </xsl:template>
 

--- a/lib/extract-header-defs.xslt
+++ b/lib/extract-header-defs.xslt
@@ -18,7 +18,7 @@
         <tr>
           <th>Field Name</th>
           <th>Status</th>
-          <th>See</th>
+          <th>Ref.</th>
         </tr>
       </thead>
       <xsl:text>&#10;</xsl:text>

--- a/lib/extract-method-defs.xslt
+++ b/lib/extract-method-defs.xslt
@@ -15,7 +15,7 @@
           <th>Method</th>
           <th>Safe</th>
           <th>Idempotent</th>
-          <th>See</th>
+          <th>Ref.</th>
         </tr>
       </thead>
       <tbody>

--- a/lib/extract-method-defs.xslt
+++ b/lib/extract-method-defs.xslt
@@ -15,7 +15,7 @@
           <th>Method</th>
           <th>Safe</th>
           <th>Idempotent</th>
-          <th>Reference</th>
+          <th>See</th>
         </tr>
       </thead>
       <tbody>
@@ -105,7 +105,7 @@
     <td><xsl:value-of select="$text"/></td>
     <td><xsl:value-of select="$safe"/></td>
     <td><xsl:value-of select="$idempotent"/></td>
-    <td><xref target="{@anchor}"/></td>
+    <td><xref target="{@anchor}" format="counter"/></td>
   </tr>
 </xsl:template>
 

--- a/lib/extract-status-code-defs.xslt
+++ b/lib/extract-status-code-defs.xslt
@@ -14,7 +14,7 @@
         <tr>
           <th>Value</th>
           <th>Description</th>
-          <th>Reference</th>
+          <th>See</th>
         </tr>
       </thead>
       <tbody>
@@ -91,7 +91,7 @@
     <tr>
       <td><xsl:value-of select="substring-before($text,' ')"/></td>
       <td><xsl:value-of select="substring($text,2+string-length(substring-before($text,' ')))"/></td>
-      <td><xref target="{@anchor}"/></td>
+      <td><xref target="{@anchor}" format="counter"/></td>
     </tr>
   </xsl:if>
 </xsl:template>

--- a/lib/extract-status-code-defs.xslt
+++ b/lib/extract-status-code-defs.xslt
@@ -14,7 +14,7 @@
         <tr>
           <th>Value</th>
           <th>Description</th>
-          <th>See</th>
+          <th>Ref.</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
did I mention that I hate line breaks in text table crossrefs?

This makes the text format much better, but the html output is worse because the stylesheet isn't padding cells. I am hoping that would be a simple fix.