### PR TITLE
remove edge case requirement for If-Match and If-Unmodified-Since

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13013,9 +13013,16 @@ transfer-coding = &lt;transfer-coding, see <xref target="Messaging" x:fmt="," x:
 
 <section title="Changes from RFC 7232" anchor="changes.from.rfc.7232">
 <t>
-   Clarify that If-Unmodified-Since doesn't apply to a resource without a
+   Clarified that If-Unmodified-Since doesn't apply to a resource without a
    concept of modification time.
    (<xref target="field.if-unmodified-since"/>)
+</t>
+<t>
+   Removed edge case requirement on If-Match and If-Unmodified-Since that a
+   validator not be sent in a 2xx response when validation fails and the server
+   decides that the same change request has already been applied.
+   (<xref target="field.if-match"/> and
+   <xref target="field.if-unmodified-since"/>)
 </t>
 </section>
 
@@ -13263,6 +13270,7 @@ transfer-coding = &lt;transfer-coding, see <xref target="Messaging" x:fmt="," x:
 
 <section title="Since draft-ietf-httpbis-semantics-10" anchor="changes.since.10">
 <ul x:when-empty="None yet.">
+  <li>In <xref target="field.if-match"/> and <xref target="field.if-unmodified-since"/>, removed requirement that a validator not be sent in a 2xx response when validation fails and the server decides that the same change request has already been applied  (<eref target="https://github.com/httpwg/http-core/issues/166"/>)</li>
   <li>In <xref target="content.coding.registry"/>, advise to make new content codings self-descriptive (<eref target="https://github.com/httpwg/http-core/issues/21"/>)</li>
   <li>In <xref target="parameter"/>, introduced the "parameters" ABNF rule, allowing empty parameters and trailing semicolons within media type, media range, and expectation (<eref target="https://github.com/httpwg/http-core/issues/33"/>)</li>
   <li>In <xref target="status.3xx"/>, explain how to create a redirected request (<eref target="https://github.com/httpwg/http-core/issues/38"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13037,16 +13037,16 @@ transfer-coding = &lt;transfer-coding, see <xref target="Messaging" x:fmt="," x:
 
 <section title="Changes from RFC 7232" anchor="changes.from.rfc.7232">
 <t>
-   Clarified that If-Unmodified-Since doesn't apply to a resource without a
-   concept of modification time.
-   (<xref target="field.if-unmodified-since"/>)
-</t>
-<t>
    Removed edge case requirement on If-Match and If-Unmodified-Since that a
    validator not be sent in a 2xx response when validation fails and the server
    decides that the same change request has already been applied.
    (<xref target="field.if-match"/> and
    <xref target="field.if-unmodified-since"/>)
+</t>
+<t>
+   Clarified that If-Unmodified-Since doesn't apply to a resource without a
+   concept of modification time.
+   (<xref target="field.if-unmodified-since"/>)
 </t>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13294,11 +13294,11 @@ transfer-coding = &lt;transfer-coding, see <xref target="Messaging" x:fmt="," x:
 
 <section title="Since draft-ietf-httpbis-semantics-10" anchor="changes.since.10">
 <ul x:when-empty="None yet.">
-  <li>In <xref target="field.if-match"/> and <xref target="field.if-unmodified-since"/>, removed requirement that a validator not be sent in a 2xx response when validation fails and the server decides that the same change request has already been applied  (<eref target="https://github.com/httpwg/http-core/issues/166"/>)</li>
   <li>In <xref target="content.coding.registry"/>, advise to make new content codings self-descriptive (<eref target="https://github.com/httpwg/http-core/issues/21"/>)</li>
   <li>In <xref target="parameter"/>, introduced the "parameters" ABNF rule, allowing empty parameters and trailing semicolons within media type, media range, and expectation (<eref target="https://github.com/httpwg/http-core/issues/33"/>)</li>
   <li>In <xref target="status.3xx"/>, explain how to create a redirected request (<eref target="https://github.com/httpwg/http-core/issues/38"/>)</li>
   <li>In <xref target="introduction"/>, revise the introduction and introduce HTTP/2 and HTTP/3 (<eref target="https://github.com/httpwg/http-core/issues/64"/>)</li>
+  <li>In <xref target="field.if-match"/> and <xref target="field.if-unmodified-since"/>, removed requirement that a validator not be sent in a 2xx response when validation fails and the server decides that the same change request has already been applied  (<eref target="https://github.com/httpwg/http-core/issues/166"/>)</li>
   <li>Moved requirements specific to HTTP/1.1 from <xref target="field.host"/> to <xref target="Messaging"/> (<eref target="https://github.com/httpwg/http-core/issues/182"/>)</li>
   <li>In <xref target="field.values"/>, introduce the terms "singleton field" and "list-based field" (also  - in various places - discuss what to do when a singleton field is received as a list) (<eref target="https://github.com/httpwg/http-core/issues/193"/>)</li>
   <li>In <xref target="field.trailer"/> (<x:ref>Trailer</x:ref>),

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6416,9 +6416,6 @@ Expect: 100-continue
    (i.e., the change requested by the user agent has already succeeded, but
    the user agent might not be aware of it, perhaps because the prior response
    was lost or a compatible change was made by some other user agent).
-   In the latter case, the origin server &MUST-NOT; send a validator header
-   field in the response unless it can verify that the request is a duplicate
-   of an immediately prior change made by the same user agent.
 </t>
 <t>
    The If-Match header field can be ignored by caches and intermediaries
@@ -6658,9 +6655,6 @@ Expect: 100-continue
    (i.e., the change requested by the user agent has already succeeded, but
    the user agent might not be aware of that because the prior response message
    was lost or a compatible change was made by some other user agent).
-   In the latter case, the origin server &MUST-NOT; send a validator header
-   field in the response unless it can verify that the request is a duplicate
-   of an immediately prior change made by the same user agent.
 </t>
 <t>
    The If-Unmodified-Since header field can be ignored by caches and

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6381,9 +6381,9 @@ Expect: 100-continue
    If-Match is most often used with state-changing methods (e.g., POST, PUT,
    DELETE) to prevent accidental overwrites when multiple user agents might be
    acting in parallel on the same resource (i.e., to prevent the "lost update"
-   problem). It can also be used with safe methods to abort a request if the
-   <x:ref>selected representation</x:ref> does not match one already stored
-   (or partially stored) from a prior request.
+   problem). It can also be used with any method to abort a request if the
+   <x:ref>selected representation</x:ref> does not match one that the client
+   has already stored (or partially stored) from a prior request.
 </t>
 <t>
    An origin server that receives an If-Match header field &MUST; evaluate the
@@ -6407,15 +6407,29 @@ Expect: 100-continue
 </ol>
 <t>
    An origin server &MUST-NOT; perform the requested method if a received
-   If-Match condition evaluates to false; instead, the origin server &MUST;
-   respond with either
-   a) the <x:ref>412 (Precondition Failed)</x:ref> status code or
-   b) one of the <x:ref>2xx (Successful)</x:ref> status codes if the origin
-   server has verified that a state change is being requested and the final
-   state is already reflected in the current state of the target resource
+   If-Match condition evaluates to false. Instead, the origin server &MAY;
+   indicate that the conditional request failed by responding with a
+   <x:ref>412 (Precondition Failed)</x:ref> status code. Alternatively,
+   if the request is a state-changing operation that appears to have already
+   been applied to the selected representation, the origin server &MAY; respond
+   with a <x:ref>2xx (Successful)</x:ref> status code
    (i.e., the change requested by the user agent has already succeeded, but
    the user agent might not be aware of it, perhaps because the prior response
-   was lost or a compatible change was made by some other user agent).
+   was lost or an equivalent change was made by some other user agent).
+</t>
+<t>
+   Allowing an origin server to send a success response when a change request
+   appears to have already been applied is more efficient for many authoring
+   use cases, but comes with some risk if multiple user agents are making
+   change requests that are very similar but not cooperative.
+   For example, multiple user agents writing to a common resource as a
+   semaphore (e.g., a non-atomic increment) are likely to collide and
+   potentially lose important state transitions. For those kinds of resources,
+   an origin server is better off being stringent in sending 412 for every
+   failed precondition on an unsafe method.
+   In other cases, excluding the ETag field from a success response might
+   encourage the user agent to perform a GET as its next request to eliminate
+   confusion about the resource's current state.
 </t>
 <t>
    The If-Match header field can be ignored by caches and intermediaries
@@ -6623,8 +6637,8 @@ Expect: 100-continue
 </t>
 <t>
    A recipient &MUST; ignore the If-Unmodified-Since header field if the
-   received field value is not a valid HTTP-date, or if the field value has
-   more than one member.
+   received field value is not a valid HTTP-date (including when the field
+   value appears to be a list of dates).
 </t>
 <t>
    A recipient &MUST; interpret an If-Unmodified-Since field value's timestamp
@@ -6635,9 +6649,9 @@ Expect: 100-continue
    (e.g., POST, PUT, DELETE) to prevent accidental overwrites when multiple
    user agents might be acting in parallel on a resource that does
    not supply entity-tags with its representations (i.e., to prevent the
-   "lost update" problem). It can also be used with safe methods to abort a
+   "lost update" problem). It can also be used with any method to abort a
    request if the <x:ref>selected representation</x:ref> does not match one
-   already stored (or partially stored) from a prior request.
+   that the client already stored (or partially stored) from a prior request.
 </t>
 <t>
    An origin server that receives an If-Unmodified-Since header field &MUST;
@@ -6645,16 +6659,26 @@ Expect: 100-continue
    the method.
 </t>
 <t>
-   If the selected representation has a last modification date, the origin server
-   &MUST-NOT; perform the requested method if that date is more recent than the date
-   provided in the field value. Instead, the origin server &MUST; respond with either
-   a) the <x:ref>412 (Precondition Failed)</x:ref> status code or
-   b) one of the <x:ref>2xx (Successful)</x:ref> status codes if the origin
-   server has verified that a state change is being requested and the final
-   state is already reflected in the current state of the target resource
+   If the selected representation has a last modification date,
+   the origin server &MUST-NOT; perform the requested method if that date is
+   more recent than the date provided in the field value.
+   Instead, the origin server &MAY; indicate that the conditional request
+   failed by responding with a <x:ref>412 (Precondition Failed)</x:ref>
+   status code. Alternatively, if the request is a state-changing operation
+   that appears to have already been applied to the selected representation,
+   the origin server &MAY; respond with a <x:ref>2xx (Successful)</x:ref>
+   status code
    (i.e., the change requested by the user agent has already succeeded, but
-   the user agent might not be aware of that because the prior response message
-   was lost or a compatible change was made by some other user agent).
+   the user agent might not be aware of it, perhaps because the prior response
+   was lost or an equivalent change was made by some other user agent).
+</t>
+<t>
+   Allowing an origin server to send a success response when a change request
+   appears to have already been applied is more efficient for many authoring
+   use cases, but comes with some risk if multiple user agents are making
+   change requests that are very similar but not cooperative.
+   In those cases, an origin server is better off being stringent in sending
+   412 for every failed precondition on an unsafe method.
 </t>
 <t>
    The If-Unmodified-Since header field can be ignored by caches and


### PR DESCRIPTION
evaluating false on a duplicate change request sending 2xx without validator for reasons unknown.

Fixes #166 