### PR TITLE
note that HTTP/2 uses something other than `Host`

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2441,6 +2441,11 @@ Host: www.example.org
    first verifying that the intercepted connection is targeting a
    valid IP address for that host.
 </t>
+<t>
+   Note that some versions of HTTP define alternative means of transferring the
+   host and port information of the target URI; see the :authority psuedo-header
+   field of <xref target="RFC7540"/>.
+</t>
 </section>
 
 <section title="Reconstructing the Target URI" anchor="reconstructing.target.uri">

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2443,7 +2443,7 @@ Host: www.example.org
 </t>
 <t>
    Note that some versions of HTTP define alternative means of transferring the
-   host and port information of the target URI; see the :authority psuedo-header
+   host and port information of the target URI; see the :authority pseudo-header
    field of <xref target="RFC7540"/>.
 </t>
 </section>


### PR DESCRIPTION
Re #511, while I agree that the semantics of the Host header field is version agnostic, how it is used (or rewritten) is version specific. IMO it would be better to clarify that in the semantics draft.