### PR TITLE
move protocol version section up to conformance

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -178,13 +178,6 @@
    protocol is now referred to as HTTP/0.9 (see <xref target="HTTP09"/>).
 </t>
 <t>
-   HTTP's version number consists of two decimal digits separated by a "."
-   (period or decimal point). The first digit ("major version") indicates the
-   messaging syntax, whereas the second digit ("minor version")
-   indicates the highest minor version within that major version to which the
-   sender is conformant (able to understand for future communication).
-</t>
-<t>
    As the Web grew, HTTP was extended to enclose requests and responses within
    messages, transfer arbitrary data formats using MIME-like media types, and
    route requests through intermediaries, eventually being defined as HTTP/1.0
@@ -498,6 +491,49 @@
    Some requests can be automatically retried by a client in the event of
    an underlying connection failure, as described in
    <xref target="idempotent.methods"/>.
+</t>
+</section>
+
+<section title="Protocol Version" anchor="protocol.version">
+<t>
+   HTTP's version number consists of two decimal digits separated by a "."
+   (period or decimal point). The first digit ("major version") indicates the
+   messaging syntax, whereas the second digit ("minor version")
+   indicates the highest minor version within that major version to which the
+   sender is conformant (able to understand for future communication).
+</t>
+<t>
+   While HTTP's core semantics don't change between protocol versions, the
+   expression of them "on the wire" can change, and so the
+   HTTP version number changes when incompatible changes are made to the wire
+   format. Additionally, HTTP allows incremental, backwards-compatible
+   changes to be made to the protocol without changing its version through
+   the use of defined extension points (<xref target="extending"/>).
+</t>
+<t>
+   The protocol version as a whole indicates the sender's conformance with
+   the set of requirements laid out in that version's corresponding
+   specification of HTTP.
+   For example, the version "HTTP/1.1" is defined by the combined
+   specifications of this document, "HTTP Caching" <xref target="Caching"/>,
+   and "HTTP/1.1" <xref target="Messaging"/>.
+</t>
+<t>
+   HTTP's major version number is incremented when an incompatible message
+   syntax is introduced. The minor number is incremented when changes made to
+   the protocol have the effect of adding to the message semantics or
+   implying additional capabilities of the sender.
+</t>
+<t>
+   The minor version advertises the sender's communication capabilities even
+   when the sender is only using a backwards-compatible subset of the
+   protocol, thereby letting the recipient know that more advanced features
+   can be used in response (by servers) or in future requests (by clients).
+</t>
+<t>
+   When a major version of HTTP does not define any minor versions, the minor
+   version "0" is implied and is used when referring to that protocol within a
+   protocol element that requires sending a minor version.
 </t>
 </section>
 </section>
@@ -1385,41 +1421,14 @@ Content-Type: text/plain
 </t>
 </section>
 
-<section title="Protocol Version" anchor="protocol.version">
+<section title="Control Data" anchor="message.control.data">
+<iref primary="true" item="control data"/>
 <t>
    Every HTTP message has a protocol version. Depending on the version in use, it
    might be carried in the message explicitly, or it might be inferred by the
    connection that the message is carried on. A message can change versions as it
    passes through intermediaries, because the semantics of a HTTP message are
    independent of its version.
-</t>
-<t>
-   While HTTP's core semantics don't change between protocol versions, the
-   expression of them "on the wire" can change, and so the
-   HTTP version number changes when incompatible changes are made to the wire
-   format. Additionally, HTTP allows incremental, backwards-compatible
-   changes to be made to the protocol without changing its version through
-   the use of defined extension points (<xref target="extending"/>).
-</t>
-<t>
-   The protocol version as a whole indicates the sender's conformance with
-   the set of requirements laid out in that version's corresponding
-   specification of HTTP.
-   For example, the version "HTTP/1.1" is defined by the combined
-   specifications of this document, "HTTP Caching" <xref target="Caching"/>,
-   and "HTTP/1.1" <xref target="Messaging"/>.
-</t>
-<t>
-   HTTP's major version number is incremented when an incompatible message
-   syntax is introduced. The minor number is incremented when changes made to
-   the protocol have the effect of adding to the message semantics or
-   implying additional capabilities of the sender.
-</t>
-<t>
-   The minor version advertises the sender's communication capabilities even
-   when the sender is only using a backwards-compatible subset of the
-   protocol, thereby letting the recipient know that more advanced features
-   can be used in response (by servers) or in future requests (by clients).
 </t>
 <t>
    A client &SHOULD; send a request version equal to the highest
@@ -1453,11 +1462,6 @@ Content-Type: text/plain
    higher minor version, when sent to a recipient that has not yet indicated
    support for that higher version, is sufficiently backwards-compatible to be
    safely processed by any implementation of the same major version.
-</t>
-<t>
-   When a major version of HTTP does not define any minor versions, the minor
-   version "0" is implied and is used when referring to that protocol within a
-   protocol element that requires sending a minor version.
 </t>
 </section>
 


### PR DESCRIPTION
 and only define the versioning there; leave message version requirements in control data.

(no content changes)