### PR TITLE
rearrange content negotiation so that all fields are at end

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6223,8 +6223,80 @@ Expect: 100-continue
    potentially even the miscellaneous text strings that might appear within
    the protocol.
 </t>
+</section>
 
-<section title="Shared Negotiation Features" anchor="conneg.shared">
+<section title="Reactive Negotiation" anchor="reactive.negotiation">
+  <x:anchor-alias value="reactive negotiation"/>
+  <x:anchor-alias value="agent-driven negotiation"/>
+<t>
+   With <x:dfn>reactive negotiation</x:dfn>
+   (a.k.a., <x:dfn>agent-driven negotiation</x:dfn>), selection of the best
+   response representation (regardless of the status code) is performed by the
+   user agent after receiving an initial response from the origin server that
+   contains a list of resources for alternative representations.
+   If the user agent is not satisfied by the initial response representation,
+   it can perform a GET request on one or more of the alternative resources,
+   selected based on metadata included in the list, to obtain a different form
+   of representation for that response. Selection of alternatives might be
+   performed automatically by the user agent or manually by the user selecting
+   from a generated (possibly hypertext) menu.
+</t>
+<t>
+   Note that the above refers to representations of the response, in general,
+   not representations of the resource. The alternative representations are
+   only considered representations of the target resource if the response in
+   which those alternatives are provided has the semantics of being a
+   representation of the target resource (e.g., a <x:ref>200 (OK)</x:ref>
+   response to a GET request) or has the semantics of providing links to
+   alternative representations for the target resource
+   (e.g., a <x:ref>300 (Multiple Choices)</x:ref> response to a GET request).
+</t>
+<t>
+   A server might choose not to send an initial representation, other than
+   the list of alternatives, and thereby indicate that reactive
+   negotiation by the user agent is preferred. For example, the alternatives
+   listed in responses with the <x:ref>300 (Multiple Choices)</x:ref> and
+   <x:ref>406 (Not Acceptable)</x:ref> status codes include information about
+   the available representations so that the user or user agent can react by
+   making a selection.
+</t>
+<t>
+   Reactive negotiation is advantageous when the response would vary
+   over commonly used dimensions (such as type, language, or encoding),
+   when the origin server is unable to determine a user agent's
+   capabilities from examining the request, and generally when public
+   caches are used to distribute server load and reduce network usage.
+</t>
+<t>
+   Reactive negotiation suffers from the disadvantages of transmitting
+   a list of alternatives to the user agent, which degrades user-perceived
+   latency if transmitted in the header section, and needing a second request
+   to obtain an alternate representation. Furthermore, this specification
+   does not define a mechanism for supporting automatic selection, though it
+   does not prevent such a mechanism from being developed as an extension.
+</t>
+</section>
+
+<section title="Request Payload Negotiation" anchor="request.payload.negotiation">
+  <x:anchor-alias value="request payload negotiation"/>
+<t>
+   When content negotiation preferences are sent in a server's response, the
+   listed preferences are called <x:dfn>request payload negotiation</x:dfn>
+   because they intend to influence selection of an appropriate payload for
+   subsequent requests to that resource. For example,
+   the <x:ref>Accept</x:ref> (<xref target="field.accept"/>) and
+   <x:ref>Accept-Encoding</x:ref> (<xref target="field.accept-encoding"/>)
+   header fields can be sent in a response to indicate preferred media types
+   and content codings for subsequent requests to that resource.
+</t>
+<t>
+   Similarly, <xref target="RFC5789" x:sec="3.1" x:fmt="of"/> defines
+   the "Accept-Patch" response header field which allows discovery of
+   which content types are accepted in PATCH requests.
+</t>
+</section>
+
+<section title="Content Negotiation Field Features" anchor="conneg.features">
 <section title="Absence" anchor="conneg.absent">
 <t>
    For each of these header fields, a request that does not contain the field
@@ -6294,6 +6366,7 @@ Expect: 100-continue
 </section>
 </section>
 
+<section title="Content Negotiation Fields" anchor="conneg.fields">
 <section title="Accept" anchor="field.accept">
   <x:anchor-alias value="header.accept"/>
   <iref primary="true" item="Fields" subitem="Accept" x:for-anchor=""/><iref primary="true" item="Header Fields" subitem="Accept" x:for-anchor=""/><iref primary="true" item="Accept header field" x:for-anchor=""/>
@@ -6659,58 +6732,6 @@ Expect: 100-continue
   </t>
 </aside>
 </section>
-</section>
-
-<section title="Reactive Negotiation" anchor="reactive.negotiation">
-  <x:anchor-alias value="reactive negotiation"/>
-  <x:anchor-alias value="agent-driven negotiation"/>
-<t>
-   With <x:dfn>reactive negotiation</x:dfn>
-   (a.k.a., <x:dfn>agent-driven negotiation</x:dfn>), selection of the best
-   response representation (regardless of the status code) is performed by the
-   user agent after receiving an initial response from the origin server that
-   contains a list of resources for alternative representations.
-   If the user agent is not satisfied by the initial response representation,
-   it can perform a GET request on one or more of the alternative resources,
-   selected based on metadata included in the list, to obtain a different form
-   of representation for that response. Selection of alternatives might be
-   performed automatically by the user agent or manually by the user selecting
-   from a generated (possibly hypertext) menu.
-</t>
-<t>
-   Note that the above refers to representations of the response, in general,
-   not representations of the resource. The alternative representations are
-   only considered representations of the target resource if the response in
-   which those alternatives are provided has the semantics of being a
-   representation of the target resource (e.g., a <x:ref>200 (OK)</x:ref>
-   response to a GET request) or has the semantics of providing links to
-   alternative representations for the target resource
-   (e.g., a <x:ref>300 (Multiple Choices)</x:ref> response to a GET request).
-</t>
-<t>
-   A server might choose not to send an initial representation, other than
-   the list of alternatives, and thereby indicate that reactive
-   negotiation by the user agent is preferred. For example, the alternatives
-   listed in responses with the <x:ref>300 (Multiple Choices)</x:ref> and
-   <x:ref>406 (Not Acceptable)</x:ref> status codes include information about
-   the available representations so that the user or user agent can react by
-   making a selection.
-</t>
-<t>
-   Reactive negotiation is advantageous when the response would vary
-   over commonly used dimensions (such as type, language, or encoding),
-   when the origin server is unable to determine a user agent's
-   capabilities from examining the request, and generally when public
-   caches are used to distribute server load and reduce network usage.
-</t>
-<t>
-   Reactive negotiation suffers from the disadvantages of transmitting
-   a list of alternatives to the user agent, which degrades user-perceived
-   latency if transmitted in the header section, and needing a second request
-   to obtain an alternate representation. Furthermore, this specification
-   does not define a mechanism for supporting automatic selection, though it
-   does not prevent such a mechanism from being developed as an extension.
-</t>
 
 <section title="Vary" anchor="field.vary">
   <x:anchor-alias value="header.vary"/>
@@ -6786,25 +6807,6 @@ Expect: 100-continue
    impact on caching.
 </t>
 </section>
-</section>
-
-<section title="Request Payload Negotiation" anchor="request.payload.negotiation">
-  <x:anchor-alias value="request payload negotiation"/>
-<t>
-   When content negotiation preferences are sent in a server's response, the
-   listed preferences are called <x:dfn>request payload negotiation</x:dfn>
-   because they intend to influence selection of an appropriate payload for
-   subsequent requests to that resource. For example,
-   the <x:ref>Accept</x:ref> (<xref target="field.accept"/>) and
-   <x:ref>Accept-Encoding</x:ref> (<xref target="field.accept-encoding"/>)
-   header fields can be sent in a response to indicate preferred media types
-   and content codings for subsequent requests to that resource.
-</t>
-<t>
-   Similarly, <xref target="RFC5789" x:sec="3.1" x:fmt="of"/> defines
-   the "Accept-Patch" response header field which allows discovery of
-   which content types are accepted in PATCH requests.
-</t>
 </section>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6132,7 +6132,10 @@ Expect: 100-continue
    where the server provides a list of representations for the user agent to
    choose from, and "request payload" negotiation, where the user agent
    selects the representation for a future request based upon the server's
-   stated preferences in past responses. Other patterns of content negotiation include
+   stated preferences in past responses.
+</t>
+<t>
+   Other patterns of content negotiation include
    "conditional content", where the representation consists of multiple
    parts that are selectively rendered based on user agent parameters, 
    "active content", where the representation contains a script that
@@ -6215,9 +6218,11 @@ Expect: 100-continue
    parts of the request information were used in the selection algorithm.
 </t>
 <t>
-   The request header fields below can be sent by a user agent to engage in
-   <x:ref>proactive negotiation</x:ref> of the response content, as defined in
-   <xref target="proactive.negotiation"/>. The preferences sent in these
+   The request header fields <x:ref>Accept</x:ref>,
+   <x:ref>Accept-Charset</x:ref>, <x:ref>Accept-Encoding</x:ref>, and
+   <x:ref>Accept-Language</x:ref> are defined below for a user agent to engage
+   in <x:ref>proactive negotiation</x:ref> of the response content.
+   The preferences sent in these
    fields apply to any content in the response, including representations of
    the target resource, representations of error or processing status, and
    potentially even the miscellaneous text strings that might appear within
@@ -6234,6 +6239,8 @@ Expect: 100-continue
    response representation (regardless of the status code) is performed by the
    user agent after receiving an initial response from the origin server that
    contains a list of resources for alternative representations.
+</t>
+<t>
    If the user agent is not satisfied by the initial response representation,
    it can perform a GET request on one or more of the alternative resources,
    selected based on metadata included in the list, to obtain a different form
@@ -6299,9 +6306,13 @@ Expect: 100-continue
 <section title="Content Negotiation Field Features" anchor="conneg.features">
 <section title="Absence" anchor="conneg.absent">
 <t>
-   For each of these header fields, a request that does not contain the field
-   implies that the user agent has no preference on that axis of negotiation.
-   If the header field is present in a request and none of the available
+   For each of the content negotiation fields, a request that does not contain
+   the field implies that the sender has no preference on that axis of
+   negotiation.
+</t>
+<t>
+   If a content negotiation header field is present in a request and none of
+   the available
    representations for the response can be considered acceptable according to
    it, the origin server can either honor the header field by sending a
    <x:ref>406 (Not Acceptable)</x:ref> response or disregard the header field
@@ -6350,9 +6361,9 @@ Expect: 100-continue
   <x:anchor-alias value="wildcard"/>
 <t>
    Most of these header fields, where indicated, define a wildcard value ("*")
-   to select unspecified values. If no wildcard is present, all values not
-   explicitly mentioned in the field are considered "not acceptable" to the
-   client.
+   to select unspecified values. If no wildcard is present, values that are
+   not explicitly mentioned in the field are considered unacceptable, except
+   for within <x:ref>Vary</x:ref> where it means the variance is unlimited.
 </t>
 <aside><t>
    &Note; In practice, using wildcards in content negotiation has limited


### PR DESCRIPTION
Fixes #565 

initial commit is just moving sections and updating headings;
second commit will update some of "the following" comments to refer to the specific fields.