### PR TITLE
clarify definition of HEAD and why some header fields differ in response

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13424,6 +13424,7 @@ Content-Type: text/plain
   <li>In <xref target="protection.space"/>, replace "canonical root URI" by "origin" (<eref target="https://github.com/httpwg/http-core/issues/542"/>)</li>
   <li>In <xref target="field.expect"/>, remove obsolete note about a change in RFC 723x (<eref target="https://github.com/httpwg/http-core/issues/547"/>)</li>
   <li>Changed to using "payload data" when defining requirements about the data being conveyed within a message, instead of the terms "payload body" or "response body" or "representation body", since they often get confused with the HTTP/1.1 message body (which includes transfer coding) (<eref target="https://github.com/httpwg/http-core/issues/553"/>)</li>
+  <li>Rewrite definition of <x:ref>HEAD</x:ref> method (<eref target="https://github.com/httpwg/http-core/issues/559"/>)</li>
   <li>In <xref target="field.if-range"/>, fix an off-by-one bug about how many chars to consider when checking for etags (<eref target="https://github.com/httpwg/http-core/issues/570"/>)</li>
   <li>In <xref target="overview.of.status.codes"/>, clarify that "no reason phrase" is fine as well (<eref target="https://github.com/httpwg/http-core/issues/571"/>)</li>
   <li>In <xref target="status.203"/>, remove an obsolete reference to the Warning response header field (<eref target="https://github.com/httpwg/http-core/issues/573"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -4551,17 +4551,25 @@ Content-Encoding: gzip
   <iref primary="true" item="Method" subitem="HEAD" x:for-anchor=""/>
 <t>
    The HEAD method is identical to GET except that the server &MUST-NOT;
-   send payload data in the response (i.e., the response terminates at the
-   end of the header section). The server &SHOULD; send the same header fields
-   in response to a HEAD request as it would have sent if the request had been
-   a GET, except that header fields that describe message body encoding or
-   transmission (e.g., <x:ref>Transfer-Encoding</x:ref>) &MAY; be omitted.
+   send payload data in the response and the response always terminates at the
+   end of the header section. HEAD is used to obtain metadata about the
+   <x:ref>selected representation</x:ref> without transferring its
+   representation data, often for the sake of testing hypertext links or
+   finding recent modifications.
 </t>
 <t>
-   HEAD is used to obtain metadata about the
-   <x:ref>selected representation</x:ref> without transferring the
-   representation data. It is often used to test hypertext links for validity,
-   accessibility, and recent modification.
+   The server &SHOULD; send the same header fields in response to a HEAD
+   request as it would have sent if the request method had been GET.
+   However, a server &MAY; omit header fields for which a value is determined
+   only while generating the payload data. For example, some servers buffer a
+   dynamic response to GET until a minimum amount of data is generated so
+   that they can more efficiently delimit small responses or make late
+   decisions with regard to content selection. Such a response to GET might
+   contain <x:ref>Content-Length</x:ref> and <x:ref>Vary</x:ref> fields, for
+   example, that are not generated within a HEAD response. These minor
+   inconsistencies are considered preferable to generating and discarding the
+   payload data for a HEAD request, since HEAD is usually requested for the
+   sake of efficiency.
 </t>
 <t>
    A payload within a HEAD request message has no defined semantics;


### PR DESCRIPTION
fixes #559 

Note that I also cleaned up the surrounding paragraph and removed parentheses from around the statement that the response always terminates after the header section.