### PR TITLE
Replace "partial request" with "range request"

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -9255,7 +9255,7 @@ Content-Range: bytes */47022
     in a <x:ref>200 (OK)</x:ref> response. That is partly because
     most clients are prepared to receive a <x:ref>200 (OK)</x:ref> to
     complete the task (albeit less efficiently) and partly because clients
-    might not stop making an invalid partial request until they have received
+    might not stop making an invalid range request until they have received
     a complete representation. Thus, clients cannot depend on receiving a
     <x:ref>416 (Range Not Satisfiable)</x:ref> response even when it is most
     appropriate.


### PR DESCRIPTION
## This PR

Replace the term "partial request" with "range request".

## Note

The terminology "partial request" has not been defined in this document.