### PR TITLE
Clarify that intermediary can forward dual TE and CL message after removing CL and processing TE

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1075,6 +1075,17 @@ https://www.example.org
    fields received in such a message.
   </t></li>
   <li><t>
+   If a message is received with both a <x:ref>Transfer-Encoding</x:ref>
+   and a <x:ref>Content-Length</x:ref> header field, the Transfer-Encoding
+   overrides the Content-Length. Such a message might indicate an attempt to
+   perform request smuggling (<xref target="request.smuggling"/>) or
+   response splitting (<xref target="response.splitting"/>) and ought to be
+   handled as an error.
+   An intermediary that chooses to forward the message &MUST; first remove the
+   received Content-Length field and process the Transfer-Encoding
+   (as described below) prior to forwarding the message downstream.
+  </t></li>
+  <li><t>
    If a <x:ref>Transfer-Encoding</x:ref> header field is present
    and the chunked transfer coding (<xref target="chunked.encoding"/>)
    is the final encoding, the message body length is determined by reading
@@ -1086,19 +1097,13 @@ https://www.example.org
    response and the chunked transfer coding is not the final encoding, the
    message body length is determined by reading the connection until it is
    closed by the server.
-   If a <x:ref>Transfer-Encoding</x:ref> header field is present in a request and the
-   chunked transfer coding is not the final encoding, the message body
-   length cannot be determined reliably; the server &MUST; respond with
-   the <x:ref>400 (Bad Request)</x:ref> status code and then close the connection.
   </t>
   <t>
-   If a message is received with both a <x:ref>Transfer-Encoding</x:ref>
-   and a <x:ref>Content-Length</x:ref> header field, the Transfer-Encoding
-   overrides the Content-Length. Such a message might indicate an attempt to
-   perform request smuggling (<xref target="request.smuggling"/>) or
-   response splitting (<xref target="response.splitting"/>) and ought to be
-   handled as an error. A sender &MUST; remove the received Content-Length
-   field prior to forwarding such a message downstream.
+   If a <x:ref>Transfer-Encoding</x:ref> header field is present in a request
+   and the chunked transfer coding is not the final encoding, the message body
+   length cannot be determined reliably; the server &MUST; respond with
+   the <x:ref>400 (Bad Request)</x:ref> status code and then close the
+   connection.
   </t></li>
   <li><t>
    If a message is received without <x:ref>Transfer-Encoding</x:ref> and with

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -3235,6 +3235,7 @@ https://www.example.org
 
 <section title="Since draft-ietf-httpbis-messaging-13" anchor="changes.since.13">
 <ul x:when-empty="None yet.">
+   <li>In <xref target="message.body.length"/>, clarify that a message needs to be checked for both Content-Length and Transfer-Encoding, before processing Transfer-Encoding, and that ought to be treated as an error, but an intermediary can choose to forward the message downstream after removing the Content-Length and processing the Transfer-Encoding (<eref target="https://github.com/httpwg/http-core/issues/617"/>)</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
Fixes #617 