### PR TITLE
transfers -> transmission

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -253,7 +253,7 @@
 <iref item="cache key" />
 <t>
    Proper cache operation preserves the semantics of HTTP transfers (<xref
-   target="Semantics"/>) while reducing the transfer of information already
+   target="Semantics"/>) while reducing the transmission of information already
    held in the cache. Although caching is an entirely &OPTIONAL; feature of
    HTTP, it can be assumed that reusing a cached response is desirable and
    that such reuse is the default behavior when no requirement or local


### PR DESCRIPTION
avoids repeating 'transfers' with different meanings