### PR TITLE
Move 'combining partial content' up

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -464,6 +464,22 @@
 </t>
 </section>
 
+<section title="Combining Partial Content" anchor="combining.responses">
+<t>
+   A response might transfer only a partial representation if the
+   connection closed prematurely or if the request used one or more Range
+   specifiers (<xref target="field.range"/>).  After several such transfers, a cache might have
+   received several ranges of the same representation.  A cache &MAY; combine
+   these ranges into a single stored response, and reuse that response to
+   satisfy later requests, if they all share the same strong validator and
+   the cache complies with the client requirements in <xref target="combining.byte.ranges"/>.
+</t>
+<t>
+   When combining the new response with one or more stored responses, a cache
+   &MUST; update the stored response header fields using the header fields
+   provided in the new response, as per <xref target="update"/>.
+</t>
+</section>
 
 <section title="Storing Responses to Authenticated Requests" anchor="caching.authenticated.responses">
 <t>
@@ -480,23 +496,6 @@
    must-revalidate (<xref target="cache-response-directive.must-revalidate"/>),
    public (<xref target="cache-response-directive.public"/>), and
    s-maxage (<xref target="cache-response-directive.s-maxage"/>).
-</t>
-</section>
-
-<section title="Combining Partial Content" anchor="combining.responses">
-<t>
-   A response might transfer only a partial representation if the
-   connection closed prematurely or if the request used one or more Range
-   specifiers (<xref target="field.range"/>).  After several such transfers, a cache might have
-   received several ranges of the same representation.  A cache &MAY; combine
-   these ranges into a single stored response, and reuse that response to
-   satisfy later requests, if they all share the same strong validator and
-   the cache complies with the client requirements in <xref target="combining.byte.ranges"/>.
-</t>
-<t>
-   When combining the new response with one or more stored responses, a cache
-   &MUST; update the stored response header fields using the header fields
-   provided in the new response, as per <xref target="update"/>.
 </t>
 </section>
 


### PR DESCRIPTION
so it's adjacent to the other range-related requirements, rather than separated from them by the authenticated requirements.