### PR TITLE
parse defensively instead of requiring an untestable reasonableness

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -428,13 +428,9 @@
 
 <section title="Length Requirements" anchor="length-requirements">
 <t>
-   When a received protocol element is parsed, the recipient &MUST; be able to
-   parse any value of reasonable length that is applicable to the recipient's
-   role and that matches the grammar defined by the corresponding ABNF rules.
-   Note, however, that some received protocol elements might not be parsed.
-   For example, an intermediary forwarding a message might parse a
-   field into generic field name and field value components, but then
-   forward the field without further parsing inside the field value.
+   A recipient &SHOULD; parse a received protocol element defensively, with
+   only marginal expectations that the element will conform to its ABNF
+   grammar and fit within a reasonable buffer size.
 </t>
 <t>
    HTTP does not have specific length limitations for many of its protocol
@@ -453,6 +449,12 @@
    server that publishes very long URI references to its own resources needs
    to be able to parse and process those same references when received as a
    target URI.
+</t>
+<t>
+   Many received protocol elements are only parsed to the extent necessary to
+   identify and forward that element downstream. For example, an intermediary
+   might parse a received field into its field name and field value components,
+   but then forward the field without further parsing inside the field value.
 </t>
 </section>
 

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13274,6 +13274,7 @@ Content-Type: text/plain
   <li>In <xref target="history.and.evolution"/>, mention that RFC 1945 describes HTTP/0.9 as well (<eref target="https://github.com/httpwg/http-core/issues/614"/>)</li>
   <li>In <xref target="field.content-range"/>, clarify that Content-Range is to be ignored in requests (<eref target="https://github.com/httpwg/http-core/issues/618"/>)</li>
   <li>In <xref target="status.421"/>, import the 421 (Misdirected Request) status code from <xref target="RFC7540"/> (<eref target="https://github.com/httpwg/http-core/issues/622"/>)</li>
+  <li>In <xref target="length-requirements"/>, rephrase the actual recipient parsing requirements (<eref target="https://github.com/httpwg/http-core/issues/634"/>)</li>
   <li>In <xref target="considerations.for.new.methods"/>, mention request target forms in considerations for new methods (<eref target="https://github.com/httpwg/http-core/issues/636"/>)</li>
 </ul>
 </section>


### PR DESCRIPTION
Fixes #634 