### PR TITLE
Even HTTP/1.0 caches now support Age and CC

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -2515,6 +2515,7 @@
 <section title="Since draft-ietf-httpbis-cache-13" anchor="changes.since.13">
 <ul x:when-empty="None yet.">
   <li>In <xref target="cache-response-directive.must-revalidate"/>, clarify requirements around generating an error response (<eref target="https://github.com/httpwg/http-core/issues/608"/>)</li>
+  <li>In <xref target="age.calculations"/>, <xref target="field.cache-control"/>, and <xref target="cache-response-directive.no-cache"/>, remove notes about very old HTTP/1.0 behaviours (<eref target="https://github.com/httpwg/http-core/issues/660"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -2526,10 +2526,10 @@
 <section title="Since draft-ietf-httpbis-cache-13" anchor="changes.since.13">
 <ul x:when-empty="None yet.">
   <li>In <xref target="cache-response-directive.must-revalidate"/>, clarify requirements around generating an error response (<eref target="https://github.com/httpwg/http-core/issues/608"/>)</li>
-  <li>In <xref target="age.calculations"/>, <xref target="field.cache-control"/>, and <xref target="cache-response-directive.no-cache"/>, remove notes about very old HTTP/1.0 behaviours (<eref target="https://github.com/httpwg/http-core/issues/660"/>)</li>
-  <li>In <xref target="freshening.responses"/>, clarify how multiple validators are handled (<eref target="https://github.com/httpwg/http-core/issues/659"/>)</li>
-  <li>In <xref target="cache-response-directive.must-understand"/>, modify operation to be more backwards-compatible with existing implementations (<eref target="https://github.com/httpwg/http-core/issues/661"/>)</li>
   <li>Changed to using "content" instead of "payload" or "payload data" to avoid confusion with the payload of version-specific messaging frames (<eref target="https://github.com/httpwg/http-core/issues/654"/>)</li>
+  <li>In <xref target="freshening.responses"/>, clarify how multiple validators are handled (<eref target="https://github.com/httpwg/http-core/issues/659"/>)</li>
+  <li>In <xref target="age.calculations"/>, <xref target="field.cache-control"/>, and <xref target="cache-response-directive.no-cache"/>, remove notes about very old HTTP/1.0 behaviours (<eref target="https://github.com/httpwg/http-core/issues/660"/>)</li>
+  <li>In <xref target="cache-response-directive.must-understand"/>, modify operation to be more backwards-compatible with existing implementations (<eref target="https://github.com/httpwg/http-core/issues/661"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -871,17 +871,14 @@
   corrected_age_value = age_value + response_delay;  
 </artwork>
 <t>
-   These are combined as
+   The corrected_age_value &MAY; be used as the corrected_initial_age. In
+   circumstances where very old cache implementations that might not correctly
+   insert <x:ref>Age</x:ref> are present, corrected_initial_age can be calculated
+   more conservatively as
 </t>
 <artwork type="code">
   corrected_initial_age = max(apparent_age, corrected_age_value);
 </artwork>
-<t>
-   unless the cache is confident in the value of the <x:ref>Age</x:ref> header
-   field (e.g., because there are no HTTP/1.0 hops in the <x:ref>Via</x:ref>
-   header field), in which case the corrected_age_value &MAY; be used as the
-   corrected_initial_age.
-</t>
 <t>
    The current_age of a stored response can then be calculated by adding the
    time (in seconds) since the stored response was last validated by
@@ -1237,10 +1234,9 @@
 </t>
 <t>
    The presence of an Age header field implies that the response was not
-   generated or validated by the origin server for this request. However,
-   lack of an Age header field does not imply the origin was contacted, since
-   the response might have been received from an HTTP/1.0 cache that does not
-   implement Age.
+   generated or validated by the origin server for this request. Note that
+   in rare circumstances, the response might have been received from an HTTP/1.0
+   cache that does not implement Age.
 </t>
 </section>
 
@@ -1259,11 +1255,6 @@
    See <xref target="cache.control.extensions"/> for information about how
    Cache-Control directives defined elsewhere are handled.
 </t>
-<aside>
-   <t>
-       &Note; Some HTTP/1.0 caches might not implement Cache-Control.
-   </t>
-</aside>
 <t>
    A proxy, whether or not it implements a cache, &MUST; pass cache directives
    through in forwarded messages, regardless of their 
@@ -1505,8 +1496,7 @@
    to be needed for single-entry lists).
 </t>
 <aside><t>
-   &Note; Although it has been back-ported to many implementations, some
-   HTTP/1.0 caches will not recognize or obey this directive. Also, the
+   &Note; The
    qualified form of the directive is often handled by caches as if an
    unqualified no-cache directive was received; i.e., the special handling
    for the qualified form is not widely implemented.

--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -1234,9 +1234,8 @@
 </t>
 <t>
    The presence of an Age header field implies that the response was not
-   generated or validated by the origin server for this request. Note that
-   in rare circumstances, the response might have been received from an HTTP/1.0
-   cache that does not implement Age.
+   generated or validated by the origin server for this request. However,
+   lack of an Age header field does not imply the origin was contacted.
 </t>
 </section>
 


### PR DESCRIPTION
... it's just deployments of very very old caches that would be of concern here.

Given how unlikely this is in 2020, how broken they would be for other reasons, and the
prevalence of HTTPS, it seems safe to modify these statements.

Fixes #660.