### PR TITLE
IP address reference identities

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1386,9 +1386,19 @@ Content-Type: text/plain
 <t>
    In general, a client &MUST; verify the service identity using the
    verification process defined in
-   <xref target="RFC6125" x:fmt="of" x:sec="6"/> (for a reference identifier of
-   type URI-ID) unless the client has been specifically configured to accept
-   some other form of verification. For example, a client might be connecting
+   <xref target="RFC6125" x:fmt="of" x:sec="6"/>. The client &MUST; construct
+   a reference identity that is a DNS-ID if the URI contains a hostname and an
+   IP-ID if the hostname was a literal IP address. Validing an IP-ID is
+   defined in <xref target="https.ip-id"/>.
+</t>
+<t>
+   A reference identity of type CN-ID MUST NOT be used by clients.  As noted
+   in <xref target="RFC6125" x:fmt="of" x:sec="6.2.1"/> a reference
+   identity of type CN-ID might be used by older clients.
+</t>
+<t>
+   Clients might be specially configured to accepted an alternative form of
+   server identity verification. For example, a client might be connecting
    to a server whose address and hostname are dynamic, with an expectation that
    the service will present a specific certificate (or a certificate matching
    some externally defined reference identity) rather than one matching the
@@ -1408,6 +1418,28 @@ Content-Type: text/plain
    and &SHOULD; terminate the connection (with a bad certificate error).
    Automated clients &MAY; provide a configuration setting that disables
    this check, but &MUST; provide a setting which enables it.
+</t>
+</section>
+<section title="IP-ID reference identity" anchor="https.ip-id">
+<t>
+   A server that is identified using an IP address literal in the "host" field
+   of an "https" URI has a reference identity of type IP-ID.  An IP version 4
+   address uses the "IPv4address" ABNF rule and an IP version 6 address uses
+   the "IP-literal" production with the "IPv6address" option; see 
+   <xref target="RFC3986" x:fmt="of" x:sec="3.2.2"/>.  A reference identity of
+   IP-ID contains the decoded bytes of the IP address.
+</t>
+<t>
+   An IP version 4 address is 4 bytes and an IP version 6 address is 16 bytes.
+   Use of IP-ID is not defined for any other IP version. The iPAddress
+   choice in the certificate subjectAltName extension does not explicitly
+   include the IP version and so relies on the length of the address to
+   distinguish versions; see
+   <xref target="RFC5280" x:fmt="of" x:sec="4.2.1.6"/>.
+</t>
+<t>
+   A reference identity of type IP-ID matches if the address is identical to
+   an iPAddress value of the subjectAltName extension of the certificate.
 </t>
 </section>
 </section>
@@ -11988,6 +12020,22 @@ Content-Type: text/plain
   </front>
   <seriesInfo name="IEEE Computer" value="17(6)"/>
   <seriesInfo name="DOI" value="10.1109/MC.1984.1659158"/>
+</reference>
+
+<reference  anchor="RFC5280" target="https://www.rfc-editor.org/info/rfc5280">
+  <front>
+    <title>Internet X.509 Public Key Infrastructure Certificate and
+           Certificate Revocation List (CRL) Profile</title>
+    <author initials="D." surname="Cooper" fullname="D. Cooper"/>
+    <author initials="S." surname="Santesson" fullname="S. Santesson"/>
+    <author initials="S." surname="Farrell" fullname="S. Farrell"/>
+    <author initials="S." surname="Boeyen" fullname="S. Boeyen"/>
+    <author initials="R." surname="Housley" fullname="R. Housley"/>
+    <author initials="W." surname="Polk" fullname="W. Polk"/>
+    <date year="2008" month="May" />
+  </front>
+  <seriesInfo name="RFC" value="5280"/>
+  <seriesInfo name="DOI" value="10.17487/RFC5280"/>
 </reference>
 
 </references>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12035,7 +12035,6 @@ Content-Type: text/plain
     <date year="2008" month="May" />
   </front>
   <seriesInfo name="RFC" value="5280"/>
-  <seriesInfo name="DOI" value="10.17487/RFC5280"/>
 </reference>
 
 </references>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1392,7 +1392,7 @@ Content-Type: text/plain
    the host is a name and the reference identity is a DNS-ID.
 </t>
 <t>
-   A reference identity of type CN-ID MUST NOT be used by clients.  As noted
+   A reference identity of type CN-ID &MUST-NOT; be used by clients.  As noted
    in <xref target="RFC6125" x:fmt="of" x:sec="6.2.1"/> a reference
    identity of type CN-ID might be used by older clients.
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1387,9 +1387,9 @@ Content-Type: text/plain
    In general, a client &MUST; verify the service identity using the
    verification process defined in
    <xref target="RFC6125" x:fmt="of" x:sec="6"/>. The client &MUST; construct
-   a reference identity that is a DNS-ID if the URI contains a hostname and an
-   IP-ID if the hostname was a literal IP address. Validing an IP-ID is
-   defined in <xref target="https.ip-id"/>.
+   a reference identity from the service's host: if the host is a literal IP address
+   (<xref target="https.ip-id"/>), the reference identity is an IP-ID, otherwise
+   the host is a name and the reference identity is a DNS-ID.
 </t>
 <t>
    A reference identity of type CN-ID MUST NOT be used by clients.  As noted
@@ -1397,7 +1397,7 @@ Content-Type: text/plain
    identity of type CN-ID might be used by older clients.
 </t>
 <t>
-   Clients might be specially configured to accepted an alternative form of
+   A client might be specially configured to accept an alternative form of
    server identity verification. For example, a client might be connecting
    to a server whose address and hostname are dynamic, with an expectation that
    the service will present a specific certificate (or a certificate matching
@@ -1430,7 +1430,7 @@ Content-Type: text/plain
    IP-ID contains the decoded bytes of the IP address.
 </t>
 <t>
-   An IP version 4 address is 4 bytes and an IP version 6 address is 16 bytes.
+   An IP version 4 address is 4 octets and an IP version 6 address is 16 octets.
    Use of IP-ID is not defined for any other IP version. The iPAddress
    choice in the certificate subjectAltName extension does not explicitly
    include the IP version and so relies on the length of the address to

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -12022,7 +12022,7 @@ Content-Type: text/plain
   <seriesInfo name="DOI" value="10.1109/MC.1984.1659158"/>
 </reference>
 
-<reference  anchor="RFC5280" target="https://www.rfc-editor.org/info/rfc5280">
+<reference anchor="RFC5280">
   <front>
     <title>Internet X.509 Public Key Infrastructure Certificate and
            Certificate Revocation List (CRL) Profile</title>


### PR DESCRIPTION
This is how it works in practice.

RFC 6125 is due for an update, I guess.  iPAddress subjectAltName has been
supported for years and years, but it never managed to capture it properly.

This is definitely a big change in that it now outlaws CN-ID.  And the
definition of IP-ID here is probably overreach, but I don't see how we can
avoid that.  I don't want to update RFC 6125 here (as much as it needs
updating), so making the definition standalone seemed like the right way to
handle it.

Closes #680.