### PR TITLE
Remove 6919 language

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -802,7 +802,7 @@
    A gateway communicates with inbound servers using any protocol that
    it desires, including private extensions to HTTP that are outside
    the scope of this specification.  However, an HTTP-to-HTTP gateway
-   that wishes to interoperate with third-party HTTP servers ought to conform
+   that wishes to interoperate with third-party HTTP servers needs to conform
    to user agent requirements on the gateway's inbound connection.
 </t>
 <t><iref primary="true" item="tunnel"/>


### PR DESCRIPTION
This isn't a place for equivocation.

This could have been MUST except that that isn't good to use here.

I considered just "conforms to" as well.  That would also work, but that is
incompatible with "wishes to" and I was less confident in removing that.  I
could do "conforms to" with "gateway that interoperates with inbound HTTP
servers", but that's a bigger change.