### PR TITLE
Try to better define "strong" encryption

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1106,7 +1106,7 @@ Content-Type: text/plain
    A client &MUST; ensure that its HTTP requests for an "https" resource are
    secured, prior to being communicated, and that it only accepts secured
    responses to those requests. Note that the definition of what cryptographic
-   mechanisms are acceptable to client and server are negotiated in TLS and
+   mechanisms are acceptable to client and server are usually negotiated and
    can change over time.
 </t>
 <t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1077,9 +1077,9 @@ Content-Type: text/plain
    (<xref target="RFC8446"/>) connection that has been secured for HTTP
    communication. In this context, <x:dfn>secured</x:dfn> specifically
    means that the server has been authenticated as acting on behalf of the
-   identified authority and all HTTP communication with that server has been
-   protected for confidentiality and integrity through the use of strong
-   encryption.
+   identified authority and all HTTP communication with that server has
+   confidentiality and integrity protection that is acceptable to both client
+   and server.
 </t>
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="https-URI"><!--terminal production--></iref>
   <x:ref>https-URI</x:ref> = "https" "://" <x:ref>authority</x:ref> <x:ref>path-abempty</x:ref> [ "?" <x:ref>query</x:ref> ]
@@ -1105,7 +1105,9 @@ Content-Type: text/plain
 <t>
    A client &MUST; ensure that its HTTP requests for an "https" resource are
    secured, prior to being communicated, and that it only accepts secured
-   responses to those requests.
+   responses to those requests. Note that the definition of what cryptographic
+   mechanisms are acceptable to client and server are negotiated in TLS and
+   can change over time.
 </t>
 <t>
    Resources made available via the "https" scheme have no shared identity


### PR DESCRIPTION
In the definition of the https scheme, the phrase "strong encryption" is used.
This implies some sort of judgment.  I think that the key is that both
client and server need to agree on the adequacy of the protections.  Noting
that this might be contextual is somewhat obvious at that point, but I thought
it might be worth pointing out that what is generally acceptable might change
over time.