### PR TITLE
A content-type converts abstract data into bits

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -3110,7 +3110,7 @@ Upgrade: websocket
    These define a two-layer, ordered encoding model:
 </t>
 <artwork type="example">
-  representation-data := Content-Encoding( Content-Type( bits ) )
+  representation-data := Content-Encoding( Content-Type( data ) )
 </artwork>
 </section>
 


### PR DESCRIPTION
The expression used here implies that a content-type is a function that
converts "bits" into a sequence of octets.  That doesn't match with my
understanding, as a content type is an encoding of some abstract data, which
might not be a linear construct, into representation data that can be
expressed in a protocol like HTTP.

I considered "abstract data", but that breaks line limits.  This seems like
a reasonable compromise.