### PR TITLE
How a HEAD response terminates is version-specific

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -4555,8 +4555,7 @@ Content-Encoding: gzip
   <iref primary="true" item="Method" subitem="HEAD" x:for-anchor=""/>
 <t>
    The HEAD method is identical to GET except that the server &MUST-NOT;
-   send content in the response and the response always terminates at the
-   end of the header section. HEAD is used to obtain metadata about the
+   send content in the response. HEAD is used to obtain metadata about the
    <x:ref>selected representation</x:ref> without transferring its
    representation data, often for the sake of testing hypertext links or
    finding recent modifications.


### PR DESCRIPTION
Though I think that this text is correct, an HTTP/3 response only ends when
the stream is closed, not at the end of the header section.  I think that it's
not necessary to say this bit anyway.