### PR TITLE
Origin servers might support CONNECT

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -4865,9 +4865,8 @@ Content-Encoding: gzip
 </t>
 <t>
    CONNECT is intended only for use in requests to a proxy.
-   An origin server that receives a CONNECT request for itself &MAY;
-   respond with a <x:ref>2xx (Successful)</x:ref> status code to indicate that a connection
-   is established.  However, most origin servers do not implement CONNECT.
+   An origin server &MAY; accept a CONNECT request, but most origin servers
+   do not implement CONNECT.
 </t>
 <t>
    A client sending a CONNECT request &MUST; send the authority component


### PR DESCRIPTION
The original text here sort of implied that it was enough for an origin server
to just send 2xx.  That assumed that the request was for the origin server
itself and elided a bunch of detail.  This is shorter and clearer, I think.