### PR TITLE
The document recommends putting Basic first

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5923,14 +5923,13 @@ Expect: 100-continue
   For instance:
 </t>
 <artwork type="example">
-  WWW-Authenticate: Newauth realm="apps", type=1,
-                    title="Login to \"apps\"", Basic realm="simple"
+  WWW-Authenticate: Basic realm="simple", Newauth realm="apps",
+                    type=1, title="Login to \"apps\""
 </artwork>
 <t>
-  This header field contains two challenges; one for the "Newauth" scheme
-  with a realm value of "apps", and two additional parameters "type" and
-  "title", and another one for the "Basic" scheme with a realm value of
-  "simple".
+  This header field contains two challenges; one for the "Basic" scheme with
+  a realm value of "simple", and another for the "Newauth" scheme with a
+  realm value of "apps", and two additional parameters "type" and "title".
 </t>
 <t>
   Some user agents do not recognise this form, however. As a result, sending


### PR DESCRIPTION
But then it has an example that contradicts this.