### PR TITLE
Make Host directly mandatory

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -708,11 +708,12 @@ Host: www.example.org:8001
    component is the same as the request-target.
    If not, then if a <x:ref>Host</x:ref> header field is supplied with a
    non-empty field value, the authority component is the same as the
-   Host field value. Otherwise, the authority component is assigned
-   the default name configured for the server and, if the connection's
-   incoming TCP port number differs from the default port for the target
-   URI's scheme, then a colon (":") and the incoming port number (in
-   decimal form) are appended to the authority component.
+   Host field value. Otherwise, if the version of the request is HTTP/1.0,
+   the authority component is assigned the default name configured for the
+   server and, if the connection's incoming TCP port number differs from
+   the default port for the target URI's scheme, then a colon (":") and
+   the incoming port number (in decimal form) are appended to the
+   authority component.
 </li>
 <li>
    If the request-target is in <x:ref>authority-form</x:ref> or
@@ -727,6 +728,14 @@ Host: www.example.org:8001
    scheme, "://", authority, and combined path and query component.
 </li>
 </ul>
+<aside>
+  <t>
+    &Note; Though absence of the <x:ref>Host<x:ref> header might be tolerated
+    by servers for compatibility with HTTP/1.0, supplying a default authority
+    makes it possible for an attacker to subvert the checks a server performs
+    on the target URI (see <xref target="Semantics" x:rel="#https.origin"/>).
+  </t>
+</aside>
 <t>
    Example 1: the following message received over an insecure TCP connection
 </t>

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -730,7 +730,7 @@ Host: www.example.org:8001
 </ul>
 <aside>
   <t>
-    &Note; Though absence of the <x:ref>Host<x:ref> header might be tolerated
+    &Note; Though absence of the <x:ref>Host</x:ref> header might be tolerated
     by servers for compatibility with HTTP/1.0, supplying a default authority
     makes it possible for an attacker to subvert the checks a server performs
     on the target URI (see <xref target="Semantics" x:rel="#https.origin"/>).

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2554,9 +2554,10 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
 </sourcecode>
 <t>
    The target URI's authority information is critical for handling a
-   request. A user agent &SHOULD; generate Host as the first field in the
-   header section of a request unless it has already generated that information
-   as an ":authority" pseudo-header field.
+   request. A user agent &MUST; generate a Host header field unless it has
+   already generated that information as an ":authority" pseudo-header field.
+   A user agent &SHOULD; generate Host as the first field in the header
+   section of a request.
 </t>
 <t>
    For example, a GET request to the origin server for

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2554,10 +2554,10 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
 </sourcecode>
 <t>
    The target URI's authority information is critical for handling a
-   request. A user agent &MUST; generate a Host header field unless it has
-   already generated that information as an ":authority" pseudo-header field.
-   A user agent &SHOULD; generate Host as the first field in the header
-   section of a request.
+   request. A user agent &MUST; generate a Host header field in a request
+   unless it sends that information as an ":authority" pseudo-header field.
+   A user agent that sends Host &SHOULD; send it as the first field in the
+   header section of a request.
 </t>
 <t>
    For example, a GET request to the origin server for


### PR DESCRIPTION
The normative language in -semantics wasn't direct enough about the
requirement for Host to be present in requests.  There was good language in
-messaging that I eventually found though, so there isn't any real problem
here, just an opportunity to improve.

I did this by taking the SHOULD...unless text and making that MUST unless,
splitting off the SHOULD that relates to putting Host as the first field line
of the header section.

Also, add a note in -messaging about supplying a default value for the
authority.

Closes #722.