### PR TITLE
Fixes for TLS connection closure

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1485,7 +1485,9 @@ https://www.example.org
    transfer coding nor Content-Length is terminated by closure of the
    connection and, thus, is considered complete regardless of the number of
    message body octets received, provided that the header section was received
-   intact.
+   intact.  When using TLS, an incomplete close cannot be used to terminate a
+   response this way; such a response is incomplete (see
+   <xref target="tls.connection.closure"/>).
 </t>
 </section>
 
@@ -1836,43 +1838,41 @@ https://www.example.org
    implementations &MUST; initiate an exchange of closure alerts before
    closing a connection. A TLS implementation &MAY;, after sending a
    closure alert, close the connection without waiting for the peer to
-   send its closure alert, generating an "incomplete close".  Note that
-   an implementation which does this &MAY; choose to reuse the session.
+   send its closure alert, generating an "incomplete close".
    This &SHOULD; only be done when the application knows (typically
-   through detecting HTTP message boundaries) that it has received all
-   the message data that it cares about.
+   through detecting HTTP message boundaries) that it has sent or
+   received all the message data that it cares about.
 </t>
 <t>
-   As specified in <xref target="RFC8446"/>, any implementation which receives a
-   connection close without first receiving a valid closure alert (a
-   "premature close") &MUST-NOT; reuse that session.  Note that a
-   premature close does not call into question the security of the data
-   already received, but simply indicates that subsequent data might
-   have been truncated. Because TLS is oblivious to HTTP
-   request/response boundaries, it is necessary to examine the HTTP data
-   itself (specifically the Content-Length header) to determine whether
-   the truncation occurred inside a message or between messages.
+   An incomplete close does not call into question the security of the data
+   already received, but it could indicate that subsequent data might have been
+   truncated. As TLS is not directly aware of HTTP message framing, it is
+   necessary to examine the HTTP data itself to determine whether messages were
+   complete. Handing of incomplete messages is defined in
+   <xref target="incomplete.messages"/>.
 </t>
 <t>
-   When encountering a premature close, a client &SHOULD; treat as completed
+   When encountering a incomplete close, a client &SHOULD; treat as completed
    all requests for which it has received as much data as specified in the
-   Content-Length header.
+   <x:ref>Content-Length</x:ref> header or, when a
+   <x:ref>Transfer-Encoding</x:ref> of chunked is used, for which the terminal
+   zero-length chunk has been received. A response that has neither chunked
+   transfer coding nor Content-Length is complete only if a valid closure alert
+   has been received. Treating an incomplete message as complete could expose
+   implementations to attack.
 </t>
 <t>
-   A client detecting an incomplete close &SHOULD; recover gracefully.  It
-   &MAY; resume a TLS session closed in this fashion.
+   A client detecting an incomplete close &SHOULD; recover gracefully.
 </t>
 <t>
    Clients &MUST; send a closure alert before closing the connection.
-   Clients which are unprepared to receive any more data &MAY; choose not
+   Clients that do not expect to receive any more data &MAY; choose not
    to wait for the server's closure alert and simply close the
    connection, thus generating an incomplete close on the server side.
 </t>
 <t>
    Servers &SHOULD; be prepared to receive an incomplete close from the client,
    since the client can often determine when the end of server data is.
-   Servers &SHOULD; be willing to resume TLS sessions closed in this
-   fashion.
 </t>
 <t>
    Servers &MUST; attempt to initiate an exchange of closure alerts with

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1852,7 +1852,7 @@ https://www.example.org
    <xref target="incomplete.messages"/>.
 </t>
 <t>
-   When encountering a incomplete close, a client &SHOULD; treat as completed
+   When encountering an incomplete close, a client &SHOULD; treat as completed
    all requests for which it has received as much data as specified in the
    <x:ref>Content-Length</x:ref> header or, when a
    <x:ref>Transfer-Encoding</x:ref> of chunked is used, for which the terminal


### PR DESCRIPTION
1. A response is incomplete if the TLS connection close was incomplete.

2. Remove text about TLS reuse/resumption, which was very inconsistent.

On the first, I removed a case of "partial closure" rather than "incomplete
closure".  I also linked the incomplete message handling section with the TLS
connection closure section.