### PR TITLE
Attempt a rewrite of message integrity text

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -2110,26 +2110,34 @@ https://www.example.org
    HTTP does not define a specific mechanism for ensuring message integrity,
    instead relying on the error-detection ability of underlying transport
    protocols and the use of length or chunk-delimited framing to detect
-   completeness. Additional integrity mechanisms, such as hash functions or
-   digital signatures applied to the content, can be selectively added to
-   messages via extensible metadata fields. Historically, the lack of
+   completeness. Historically, the lack of
    a single integrity mechanism has been justified by the informal nature of
    most HTTP communication.  However, the prevalence of HTTP as an information
    access mechanism has resulted in its increasing use within environments
    where verification of message integrity is crucial.
 </t>
 <t>
-   User agents are encouraged to implement configurable means for detecting
-   and reporting failures of message integrity such that those means can be
-   enabled within environments for which integrity is necessary. For example,
-   a browser being used to view medical history or drug interaction
+   The mechanisms provided with the "https" scheme, such as authenticated
+   encryption, provide protection against modification of messages. Care
+   is needed however to ensure that connection closure cannot be used to
+   truncate messages (see <xref target="tls.connection.closure"/>). User agents
+   might refuse to accept incomplete messages or treat them specially. For
+   example, a browser being used to view medical history or drug interaction
    information needs to indicate to the user when such information is detected
    by the protocol to be incomplete, expired, or corrupted during transfer.
    Such mechanisms might be selectively enabled via user agent extensions or
    the presence of message integrity metadata in a response.
-   At a minimum, user agents ought to provide some indication that allows a
-   user to distinguish between a complete and incomplete response message
-   (<xref target="incomplete.messages"/>) when such verification is desired.
+</t>
+<t>
+   The "http" scheme provides no protection against accidental or malicious
+   modification of messages.
+</t>
+<t>
+   Extensions to the protocol might be used to mitigate the risk of unwanted
+   modification of messages by intermediaries, even when the "https" scheme is
+   used. Integrity might be assured by using hash functions or digital
+   signatures that are selectively added to messages via extensible metadata
+   fields.
 </t>
 </section>
 


### PR DESCRIPTION
I didn't want to make this too disruptive, so I concentrated on the high
points.  Related to the changes in #734.

Breakdown:
 - integrity is important (existing text)
 - HTTPS provides integrity, but you have to be careful with truncation
   (includes existing example)
 - HTTP provides no integrity
 - extensions can be used to provide additional protection, including
   managing the risk of intermediaries messing around (massaging existing
   text)

Closes #726.