### PR TITLE
A CONNECT tunnel starts after the response header section

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -4918,21 +4918,20 @@ Host: server.example.com
    into the protocol's wire format.
 </t>
 <t>
-   CONNECT is intended only for use in requests to a proxy.
+   CONNECT is intended for use in requests to a proxy.
+   The recipient can establish a tunnel either by directly connecting to
+   the server identified by the request target or, if configured to use
+   another proxy, by forwarding the CONNECT request to the next inbound proxy.
    An origin server &MAY; accept a CONNECT request, but most origin servers
    do not implement CONNECT.
 </t>
 <t>
-   The recipient proxy can establish a tunnel either by directly connecting to
-   the request target or, if configured to use another proxy, by forwarding
-   the CONNECT request to the next inbound proxy.
    Any <x:ref>2xx (Successful)</x:ref> response indicates
    that the sender (and all inbound proxies) will switch to tunnel mode
-   immediately after the blank line that concludes the successful response's
-   header section; data received after that blank line is from the server
-   identified by the request target.
+   immediately after the response header section; data received after that
+   header section is from the server identified by the request target.
    Any response other than a successful response indicates that the tunnel
-   has not yet been formed and that the connection remains governed by HTTP.
+   has not yet been formed.
 </t>
 <t>
    A tunnel is closed when a tunnel intermediary detects that either side
@@ -13455,7 +13454,7 @@ Content-Type: text/plain
   <li>Remove "Canonicalization and Text Defaults" (<eref target="https://github.com/httpwg/http-core/issues/703"/>)</li>
   <li>In <xref target="charset"/>, remove the "charset" ABNF production, and clarify where charsets appear (<eref target="https://github.com/httpwg/http-core/issues/713"/>)</li>
   <li>In <xref target="field.accept-encoding"/>, clarify that selection <em>between</em> multiple acceptable codings is only relevant when they have the same purpose (<eref target="https://github.com/httpwg/http-core/issues/714"/>)</li>
-  <li>In <xref target="CONNECT"/>, clarify that the port is mandatory in a CONNECT request target (<eref target="https://github.com/httpwg/http-core/issues/736"/>)</li>
+  <li>In <xref target="CONNECT"/>, clarify that the port is mandatory in a CONNECT request target (<eref target="https://github.com/httpwg/http-core/issues/736"/>) and that the tunnel begins after the header section (<eref target="https://github.com/httpwg/http-core/issues/737"/>)</li>
   <li>In <xref target="connections"/>, clarify duplexing semantics (<eref target="https://github.com/httpwg/http-core/issues/741"/>)</li>
   <li>In <xref target="connections"/>, explain the implications of statelessness more clearly (<eref target="https://github.com/httpwg/http-core/issues/743"/>)</li>
   <li>In <xref target="field.content-length"/>, be more explicit about invalid and incorrect values (<eref target="https://github.com/httpwg/http-core/issues/748"/> and <eref target="https://github.com/httpwg/http-core/issues/749"/>)</li>


### PR DESCRIPTION
Fixes #737 