### PR TITLE
The extent of a protection space is unknowable

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13465,6 +13465,7 @@ Content-Type: text/plain
   <li>In <xref target="field.content-length"/>, be more explicit about invalid and incorrect values (<eref target="https://github.com/httpwg/http-core/issues/748"/> and <eref target="https://github.com/httpwg/http-core/issues/749"/>)</li>
   <li>Move discussion of statelessness from <xref target="intermediaries"/> to <xref target="connections"/> (<eref target="https://github.com/httpwg/http-core/issues/753"/>)</li>
   <li>In <xref target="status.101"/>, clarify that the upgraded protocol is in effect after the 101 response (<eref target="https://github.com/httpwg/http-core/issues/776"/>)</li>
+  <li>In <xref target="protection.scope"/>, explain that the protection scope is not defined without additional information (<eref target="https://github.com/httpwg/http-core/issues/710"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5917,9 +5917,15 @@ Expect: 100-continue
    user agent &MAY; reuse the same credentials for all other requests within
    that protection space for a period of time determined by the authentication
    scheme, parameters, and/or user preferences (such as a configurable
-   inactivity timeout). Unless specifically allowed by the authentication
-   scheme, a single protection space cannot extend outside the scope of its
-   server.
+   inactivity timeout).
+</t>
+<t>
+   The extent of a protection space, and therefore the requests to which
+   credentials might be automatically applied, is not necessarily known to
+   clients without additional information. An authentication scheme might
+   define parameters that describe the extent of a protection space. Unless
+   specifically allowed by the authentication scheme, a single protection
+   space cannot extend outside the scope of its server.
 </t>
 <t>
    For historical reasons, a sender &MUST; only generate the quoted-string syntax.


### PR DESCRIPTION
When the text suggests that credentials can be automatically applied to all
requests made within a protection space, that begs the question: how do I know
what requests are in the same protection space?

The answer is "well, you don't really".  Authentication schemes might define
something, but otherwise you are left to guess.  This PR says that as directly
as I could manage.

I considered adding another sentence here that says "In the absence of
specific information about the extent of a protection space, clients &MAY;
assume that the protection space extent is the origin of the server."  I'd
like thoughts on whether that is helpful.  I think that it might be, as otherwise
this isn't really implementable.

Closes #710.