### PR TITLE
Remove TRACE requirement on message/http media type (last normative ref to HTTP/1.1)

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13042,6 +13042,11 @@ Content-Type: text/plain
    (<xref target="OPTIONS"/>)
 </t>
 <t>
+   Removed normative requirement to use the "message/http" media type in
+   TRACE responses.
+   (<xref target="TRACE"/>)
+</t>
+<t>
    Restore list-based grammar for <x:ref>Expect</x:ref> for compatibility with
    RFC 2616.
    (<xref target="field.expect"/>)

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -9711,7 +9711,7 @@ Content-Type: text/plain
    data format, since orthogonal technologies deserve orthogonal specification.
 </t>
 <t>
-   Since message parsing (<xref target="message.body"/>) needs to be
+   Since message parsing (<xref target="message.abstraction"/>) needs to be
    independent of method
    semantics (aside from responses to HEAD), definitions of new methods
    cannot change the parsing algorithm or prohibit the presence of content

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -5061,9 +5061,8 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
    The TRACE method requests a remote, application-level loop-back of the
    request message. The final recipient of the request &SHOULD; reflect the
    message received, excluding some fields described below, back to the client
-   as the content of a <x:ref>200 (OK)</x:ref> response with a
-   <x:ref>Content-Type</x:ref> of "message/http"
-   (<xref target="media.type.message.http"/>).
+   as the content of a <x:ref>200 (OK)</x:ref> response. The "message/http"
+   (<xref target="media.type.message.http"/>) format is one way to do so.
    The final recipient is either the origin server or the first server to
    receive a <x:ref>Max-Forwards</x:ref> value of zero (0) in the request
    (<xref target="field.max-forwards"/>).

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13482,7 +13482,7 @@ Content-Type: text/plain
   <li>In <xref target="connections"/>, explain the implications of statelessness more clearly (<eref target="https://github.com/httpwg/http-core/issues/743"/>)</li>
   <li>In <xref target="field.content-length"/>, be more explicit about invalid and incorrect values (<eref target="https://github.com/httpwg/http-core/issues/748"/> and <eref target="https://github.com/httpwg/http-core/issues/749"/>)</li>
   <li>Move discussion of statelessness from <xref target="intermediaries"/> to <xref target="connections"/> (<eref target="https://github.com/httpwg/http-core/issues/753"/>)</li>
-  <li>In <xref target="status.101"/>, clarify that the upgraded protocol is in effect after the 101 response (<eref target="https://github.com/httpwg/http-core/issues/776"/>)</li
+  <li>In <xref target="status.101"/>, clarify that the upgraded protocol is in effect after the 101 response (<eref target="https://github.com/httpwg/http-core/issues/776"/>)</li>
   <li>Throughout, remove unneeded normative references to <xref target="Messaging"/> (<eref target="https://github.com/httpwg/http-core/issues/795"/>)</li>
 </ul>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13467,7 +13467,7 @@ Content-Type: text/plain
   <li>In <xref target="status.codes"/>, clarify that status code values outside the range 100..599 are invalid, and recommend error handling (<eref target="https://github.com/httpwg/http-core/issues/684"/>)</li>
   <li>In <xref target="requirements.notation"/>, replaced requirement on semantic conformance with permission to ignore/workaround implementation-specific failures (<eref target="https://github.com/httpwg/http-core/issues/687"/>)</li>
   <li>Avoid the term "whitelist" (<eref target="https://github.com/httpwg/http-core/issues/688"/>)</li>
-  <li>Remove remaining normative references to HTTP/1.1 (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
+  <li>In <xref targret="TRACE"/>, remove the normative requirement to use the message/http media type (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
   <li>In <xref target="message.forwarding"/>, discuss extensibility (<eref target="https://github.com/httpwg/http-core/issues/692"/>)</li>
   <li>In <xref target="field-values"/>, tighten the recommendation for characters in newly defined fields, making it consistent with obs-text (<eref target="https://github.com/httpwg/http-core/issues/696"/>)</li>
   <li>Remove "Canonicalization and Text Defaults" (<eref target="https://github.com/httpwg/http-core/issues/703"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -11840,25 +11840,6 @@ Content-Type: text/plain
 
 <references title="Normative References">
 
-<reference anchor="Messaging">
-  <x:source href="draft-ietf-httpbis-messaging-latest.xml" basename="draft-ietf-httpbis-messaging-latest">
-    <x:has anchor="body.content-length"/>
-    <x:has anchor="compatibility.with.http.1.0.persistent.connections"/>
-    <x:has anchor="chunked.trailer.section"/>
-    <x:has anchor="field.parsing"/>
-    <x:has anchor="h1.effective.request.uri"/>
-    <x:has anchor="field.transfer-encoding"/>
-    <x:has anchor="media.type.message.http"/>
-    <x:has anchor="line.folding"/>
-    <x:has anchor="message.body"/>
-    <x:has anchor="persistent.tear-down"/>
-    <x:has anchor="persistent.failures"/>
-    <x:has anchor="request.smuggling"/>
-    <x:has anchor="transfer.codings"/>
-    <x:has anchor="Messaging-security.considerations" target="security.considerations"/>
-  </x:source>
-</reference>
-
 <reference anchor="Caching">
   <x:source href="draft-ietf-httpbis-cache-latest.xml" basename="draft-ietf-httpbis-cache-latest">
     <x:has anchor="constructing.responses.from.caches"/>
@@ -12081,6 +12062,25 @@ Content-Type: text/plain
 </references>
 
 <references title="Informative References">
+
+<reference anchor="Messaging">
+  <x:source href="draft-ietf-httpbis-messaging-latest.xml" basename="draft-ietf-httpbis-messaging-latest">
+    <x:has anchor="body.content-length"/>
+    <x:has anchor="compatibility.with.http.1.0.persistent.connections"/>
+    <x:has anchor="chunked.trailer.section"/>
+    <x:has anchor="field.parsing"/>
+    <x:has anchor="h1.effective.request.uri"/>
+    <x:has anchor="field.transfer-encoding"/>
+    <x:has anchor="media.type.message.http"/>
+    <x:has anchor="line.folding"/>
+    <x:has anchor="message.body"/>
+    <x:has anchor="persistent.tear-down"/>
+    <x:has anchor="persistent.failures"/>
+    <x:has anchor="request.smuggling"/>
+    <x:has anchor="transfer.codings"/>
+    <x:has anchor="Messaging-security.considerations" target="security.considerations"/>
+  </x:source>
+</reference>
 
 <reference anchor="Err1912" target="https://www.rfc-editor.org/errata/eid1912" quoteTitle="false">
   <front>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13500,6 +13500,7 @@ Content-Type: text/plain
   <li>In <xref target="field.content-length"/>, be more explicit about invalid and incorrect values (<eref target="https://github.com/httpwg/http-core/issues/748"/> and <eref target="https://github.com/httpwg/http-core/issues/749"/>)</li>
   <li>Move discussion of statelessness from <xref target="intermediaries"/> to <xref target="connections"/> (<eref target="https://github.com/httpwg/http-core/issues/753"/>)</li>
   <li>In <xref target="status.101"/>, clarify that the upgraded protocol is in effect after the 101 response (<eref target="https://github.com/httpwg/http-core/issues/776"/>)</li>
+  <li>Remove remaining normative references to HTTP/1.1 (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -10227,7 +10227,7 @@ Content-Type: text/plain
 </ul>
 <t>
    Names of content codings &MUST-NOT; overlap with names of transfer codings
-   (<xref target="transfer.codings"/>), unless the encoding transformation is
+   (as per the HTTP Transfer Coding registry), unless the encoding transformation is
    identical (as is the case for the compression codings defined in
    <xref target="content.codings"/>).
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13467,7 +13467,7 @@ Content-Type: text/plain
   <li>In <xref target="status.codes"/>, clarify that status code values outside the range 100..599 are invalid, and recommend error handling (<eref target="https://github.com/httpwg/http-core/issues/684"/>)</li>
   <li>In <xref target="requirements.notation"/>, replaced requirement on semantic conformance with permission to ignore/workaround implementation-specific failures (<eref target="https://github.com/httpwg/http-core/issues/687"/>)</li>
   <li>Avoid the term "whitelist" (<eref target="https://github.com/httpwg/http-core/issues/688"/>)</li>
-  <li>In <xref targret="TRACE"/>, remove the normative requirement to use the message/http media type (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
+  <li>In <xref target="TRACE"/>, remove the normative requirement to use the message/http media type (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
   <li>In <xref target="message.forwarding"/>, discuss extensibility (<eref target="https://github.com/httpwg/http-core/issues/692"/>)</li>
   <li>In <xref target="field-values"/>, tighten the recommendation for characters in newly defined fields, making it consistent with obs-text (<eref target="https://github.com/httpwg/http-core/issues/696"/>)</li>
   <li>Remove "Canonicalization and Text Defaults" (<eref target="https://github.com/httpwg/http-core/issues/703"/>)</li>


### PR DESCRIPTION
Fixes #690.