### PR TITLE
Clarify that HTTP self-descriptive messages have an exception …

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2169,7 +2169,13 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    looking at the message itself, after decoding or reconstituting parts that
    have been compressed or elided in transit, without requiring an
    understanding of the sender's current application state (established via
-   prior messages).
+   prior messages). However, there is one significant exception: each
+   response relies on prior understanding of its corresponding request.
+   A client might need to remember the method, target URI, HTTP version, and
+   content negotiation fields that it used for a given request in order to
+   correctly parse, interpret, or cache the response. For example, responses
+   to the <x:ref>HEAD</x:ref> method look just like the beginning of a
+   response to <x:ref>GET</x:ref>, but cannot be parsed the same.
 </t>
 <t>
    Note that this message abstraction is a generalization across many versions

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2169,10 +2169,9 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    looking at the message itself, after decoding or reconstituting parts that
    have been compressed or elided in transit, without requiring an
    understanding of the sender's current application state (established via
-   prior messages). However, a response must be understood within the context
-   of its corresponding request in order to
-   correctly parse, interpret, or cache the response. For example, responses
-   to the <x:ref>HEAD</x:ref> method look just like the beginning of a
+   prior messages). However, a client &MUST; retain knowledge of the request when
+   parsing, interpreting, or caching a corresponding response. For example,
+   responses to the <x:ref>HEAD</x:ref> method look just like the beginning of a
    response to <x:ref>GET</x:ref>, but cannot be parsed in the same manner.
 </t>
 <t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13481,6 +13481,7 @@ Content-Type: text/plain
   <li>In <xref target="TRACE"/>, remove the normative requirement to use the message/http media type (<eref target="https://github.com/httpwg/http-core/issues/690"/>)</li>
   <li>In <xref target="message.forwarding"/>, discuss extensibility (<eref target="https://github.com/httpwg/http-core/issues/692"/>)</li>
   <li>In <xref target="field-values"/>, tighten the recommendation for characters in newly defined fields, making it consistent with obs-text (<eref target="https://github.com/httpwg/http-core/issues/696"/>)</li>
+  <li>In <xref target="message.abstraction"/>, clarify that HTTP self-descriptive messages have an exception in that the request must be understood in order to parse and interpret the response (<eref target="https://github.com/httpwg/http-core/issues/700"/>)</li>
   <li>Remove "Canonicalization and Text Defaults" (<eref target="https://github.com/httpwg/http-core/issues/703"/>)</li>
   <li>In <xref target="field.referer"/>, refine what can be sent in Referer, and when (<eref target="https://github.com/httpwg/http-core/issues/709"/>)</li>
   <li>In <xref target="protection.space"/>, explain that the protection space is not defined without additional information (<eref target="https://github.com/httpwg/http-core/issues/710"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -2169,13 +2169,11 @@ Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format
    looking at the message itself, after decoding or reconstituting parts that
    have been compressed or elided in transit, without requiring an
    understanding of the sender's current application state (established via
-   prior messages). However, there is one significant exception: each
-   response relies on prior understanding of its corresponding request.
-   A client might need to remember the method, target URI, HTTP version, and
-   content negotiation fields that it used for a given request in order to
+   prior messages). However, a response must be understood within the context
+   of its corresponding request in order to
    correctly parse, interpret, or cache the response. For example, responses
    to the <x:ref>HEAD</x:ref> method look just like the beginning of a
-   response to <x:ref>GET</x:ref>, but cannot be parsed the same.
+   response to <x:ref>GET</x:ref>, but cannot be parsed in the same manner.
 </t>
 <t>
    Note that this message abstraction is a generalization across many versions


### PR DESCRIPTION
…  in that the request must be understood in order to parse and interpret the response.

Fixes #700 
