### PR TITLE
Fix:  #827. Other media-types are fine for 303 responses

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -8980,6 +8980,8 @@ Content-Range: bytes 7000-7999/8000
    Except for responses to a HEAD request, the representation of a 303
    response ought to contain a short hypertext note with a hyperlink to the
    same URI reference provided in the <x:ref>Location</x:ref> header field.
+   If the response is not intended for a browser, it is correct
+   to use other suitable media-types, such as application/json.
 </t>
 </section>
 


### PR DESCRIPTION
## This PR

Tries to clarify that it is perfectly interoperable to use other media-types (eg. application/json) in 303 responses.

IMHO the current wording suggests that not returning a short hypertext is not a best practice.

See #827 
