### PR TITLE
(editorial) tweaks inspired by kaduk suggestions from IESG review

### DIFF
--- a/draft-ietf-httpbis-cache-latest.xml
+++ b/draft-ietf-httpbis-cache-latest.xml
@@ -583,11 +583,12 @@
 <section title="Calculating Cache Keys with the Vary Header Field" anchor="caching.negotiated.responses">
 <t>
    When a cache receives a request that can be satisfied by a stored response
-   that has a <x:ref>Vary</x:ref> header field (<xref target="field.vary"/>),
-   it &MUST-NOT; use that response unless all the selecting header fields
-   nominated by the Vary header field match in both the original request
-   (i.e., that associated with the stored response), and the presented
-   request.
+   and that stored response contains a <x:ref>Vary</x:ref> header field
+   (<xref target="field.vary"/>),
+   the cache &MUST-NOT; use that stored response without revalidation unless
+   all the selecting header fields (nominated by that Vary field value) in the
+   present request match those fields in the original request (i.e., the
+   request that caused the cached response to be stored).
 </t>
 <t>
    The selecting header fields from two requests are defined to match if
@@ -616,7 +617,8 @@
    there.
 </t>
 <t>
-   A <x:ref>Vary</x:ref> header field value containing a member "*" always fails to match.
+   A stored response with a <x:ref>Vary</x:ref> header field value containing
+   a member "*" always fails to match.
 </t>
 <iref item="selected response" />
 <t>
@@ -713,7 +715,7 @@
 </t>
 <t>
    Clients can send the max-age or min-fresh request directives (<xref
-   target="cache-request-directive" />) to constrain or relax freshness
+   target="cache-request-directive" />) to suggest limits on the freshness
    calculations for the corresponding response. However, caches are not
    required to honor them.
 </t>
@@ -760,8 +762,8 @@
    target="heuristic.freshness" />.</li>
 </ul>
 <t>
-   Note that this calculation is not vulnerable to clock skew, since all of
-   the information comes from the origin server.
+   Note that this calculation is intended to reduce clock skew by using the
+   clock information provided by the origin server whenever possible.
 </t>
 <t>
    When there is more than one value present for a given directive (e.g., two


### PR DESCRIPTION
replaces #874 with my own edits.

Note that I added "without revalidation" to the description of Vary since the cache can use the stored response, regardless of Vary, once it has been revalidated by the origin server (e.g., 304 with etag).