### PR TITLE
(editorial) remove bit about accepting absolute-form for potential transition

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -624,10 +624,7 @@ GET http://www.example.org/pub/WWW/TheProject.html HTTP/1.1
 </t>
 <t>
    A server &MUST; accept the absolute-form in requests even though most
-   HTTP/1.1 clients will only send the absolute-form to a proxy. This allows
-   servers to be deployed in non-traditional configurations, such as within a
-   custom service mesh or content distribution network, where the proxy/origin
-   distinction is handled upstream.
+   HTTP/1.1 clients will only send the absolute-form to a proxy.
 </t>
 </section>
 

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -623,11 +623,11 @@ GET http://www.example.org/pub/WWW/TheProject.html HTTP/1.1
    empty Host header field will be sent in this case.
 </t>
 <t>
-   To allow for the possibility of a transition
-   to the absolute-form for all requests in some
-   future version of HTTP, a server &MUST; accept the absolute-form
-   in requests, even though HTTP/1.1 clients will only send them in requests
-   to proxies.
+   A server &MUST; accept the absolute-form in requests even though most
+   HTTP/1.1 clients will only send the absolute-form to a proxy. This allows
+   servers to be deployed in non-traditional configurations, such as within a
+   custom service mesh or content distribution network, where the proxy/origin
+   distinction is handled upstream.
 </t>
 </section>
 


### PR DESCRIPTION
This is related to the suggestion in #872 but provides the modern reason why all servers work this way.
