### PR TITLE
clarify that Accept-Ranges can be sent by any server

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7911,6 +7911,11 @@ Accept-Ranges: bytes
    improving performance and reducing unnecessary network transfers.
 </t>
 <t>
+   Conversely, a client &MUST-NOT; assume that receiving an Accept-Ranges field means that future requests
+   will return partial responses. The server might not support future range requests, or the header might have
+   been added by an intermediary on a different path.
+</t>
+<t>
    A server that does not support any kind of range request for the target
    resource &MAY; send
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7885,24 +7885,29 @@ bytes=500-700,601-999
   <x:anchor-alias value="Accept-Ranges"/>
   <x:anchor-alias value="acceptable-ranges"/>
 <t>
-   The "Accept-Ranges" header field allows a server to indicate that it
-   supports range requests for the target resource.
+   The "Accept-Ranges" field in a response indicates whether an upstream
+   server supports range requests for the target resource.
 </t>
 <sourcecode type="abnf7230"><iref primary="true" item="Grammar" subitem="Accept-Ranges"/><iref primary="true" item="Grammar" subitem="acceptable-ranges"/>
   <x:ref>Accept-Ranges</x:ref>     = <x:ref>acceptable-ranges</x:ref>
-  <x:ref>acceptable-ranges</x:ref> = 1#<x:ref>range-unit</x:ref> / "none"
+  <x:ref>acceptable-ranges</x:ref> = 1#<x:ref>range-unit</x:ref>
 </sourcecode>
 <t>
-   An origin server that supports byte-range requests for a given target
-   resource &MAY; send
+   For example, a server that supports
+   <xref target="byte.ranges">byte-range requests</xref> can send the field
 </t>
 <sourcecode type="http-message">
 Accept-Ranges: bytes
 </sourcecode>
 <t>
-   to indicate what range units are supported. A client &MAY; generate range
-   requests without having received this header field for the resource
-   involved. Range units are defined in <xref target="range.units"/>.
+   to indicate that the request's target resource supports range requests,
+   thereby encouraging its use by the client for future partial requests.
+   Range units are defined in <xref target="range.units"/>.
+</t>
+<t>
+   A client &MAY; generate range requests regardless of having received an
+   Accept-Ranges field. The information only provides advice for the sake of
+   improving performance and reducing unnecessary network transfers.
 </t>
 <t>
    A server that does not support any kind of range request for the target
@@ -7912,7 +7917,14 @@ Accept-Ranges: bytes
 Accept-Ranges: none
 </sourcecode>
 <t>
-   to advise the client not to attempt a range request.
+   to advise the client not to attempt a range request. The range unit "none"
+   is reserved for this purpose.
+</t>
+<t>
+   The Accept-Ranges field &MAY; be sent in a trailer section, but is preferred
+   to be sent as a header field because the information is particularly useful
+   for restarting large information transfers that have failed in mid-content
+   (before the trailer section is received).
 </t>
 </section>
 
@@ -12888,8 +12900,7 @@ Content-Type: text/plain
 
 <x:ref>absolute-URI</x:ref> = &lt;absolute-URI, see <xref target="RFC3986" x:fmt="," x:sec="4.3"/>&gt;
 <x:ref>absolute-path</x:ref> = 1*( "/" segment )
-<x:ref>acceptable-ranges</x:ref> = ( range-unit *( OWS "," OWS range-unit ) ) /
- "none"
+<x:ref>acceptable-ranges</x:ref> = range-unit *( OWS "," OWS range-unit )
 <x:ref>asctime-date</x:ref> = day-name SP date3 SP time-of-day SP year
 <x:ref>auth-param</x:ref> = token BWS "=" BWS ( token / quoted-string )
 <x:ref>auth-scheme</x:ref> = token

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7901,7 +7901,8 @@ Accept-Ranges: bytes
 </sourcecode>
 <t>
    to indicate that it supports byte range requests for that target resource,
-   thereby encouraging its use by the client for future partial requests.
+   thereby encouraging its use by the client for future partial requests on
+   the same request path.
    Range units are defined in <xref target="range.units"/>.
 </t>
 <t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7900,7 +7900,7 @@ bytes=500-700,601-999
 Accept-Ranges: bytes
 </sourcecode>
 <t>
-   to indicate that the request's target resource supports range requests,
+   to indicate that it supports byte range requests for that target resource,
    thereby encouraging its use by the client for future partial requests.
    Range units are defined in <xref target="range.units"/>.
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13650,6 +13650,7 @@ Content-Type: text/plain
 <ul x:when-empty="None yet.">
   <li>In <xref target="status.206"/>, reinstate 'to a request' (<eref target="https://github.com/httpwg/http-core/issues/857"/>)</li>
   <li>Align <xref target="fields.registry"/> with <xref target="considerations.for.new.field.names"/> (<eref target="https://github.com/httpwg/http-core/issues/857"/>)</li>
+  <li>In <xref target="field.accept-ranges"/>, clarify that Accept-Ranges can be sent by any server, remove "none" from the ABNF because it is now a reserved range unit, and allow the field to be sent in a trailer section while noting why that is much less useful than as a header field (<eref target="https://github.com/httpwg/http-core/issues/857"/>)</li>
   <li>In <xref target="field.via"/>, don't specify TCP (<eref target="https://github.com/httpwg/http-core/issues/865"/>)</li>
   <li>In <xref target="content"/>, explain the "Content-" prefix (<eref target="https://github.com/httpwg/http-core/issues/878"/>)</li>
   <li>In <xref target="routing.reject"/>, check all target URIs for scheme semantic mismatches (<eref target="https://github.com/httpwg/http-core/issues/896"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7918,8 +7918,8 @@ Accept-Ranges: bytes
 Accept-Ranges: none
 </sourcecode>
 <t>
-   to advise the client not to attempt a range request on the current request path. The range unit "none"
-   is reserved for this purpose.
+   to advise the client not to attempt a range request on the same request path.
+   The range unit "none" is reserved for this purpose.
 </t>
 <t>
    The Accept-Ranges field &MAY; be sent in a trailer section, but is preferred

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7911,9 +7911,10 @@ Accept-Ranges: bytes
    improving performance and reducing unnecessary network transfers.
 </t>
 <t>
-   Conversely, a client &MUST-NOT; assume that receiving an Accept-Ranges field means that future requests
-   will return partial responses. The server might not support future range requests, or the header might have
-   been added by an intermediary on a different path.
+   Conversely, a client &MUST-NOT; assume that receiving an Accept-Ranges field
+   means that future range requests will return partial responses. The content might
+   change, the server might only support range requests at certain times or under
+   certain conditions, or a different intermediary might process the next request.
 </t>
 <t>
    A server that does not support any kind of range request for the target

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7917,7 +7917,7 @@ Accept-Ranges: bytes
 Accept-Ranges: none
 </sourcecode>
 <t>
-   to advise the client not to attempt a range request. The range unit "none"
+   to advise the client not to attempt a range request on the current request path. The range unit "none"
    is reserved for this purpose.
 </t>
 <t>

--- a/httpbis.abnf
+++ b/httpbis.abnf
@@ -63,7 +63,7 @@ WWW-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
 absolute-URI = <absolute-URI, see [RFC3986], Section 4.3>
 absolute-form = absolute-URI
 absolute-path = 1*( "/" segment )
-acceptable-ranges = ( range-unit *( OWS "," OWS range-unit ) ) / "none"
+acceptable-ranges = range-unit *( OWS "," OWS range-unit )
 asctime-date = day-name SP date3 SP time-of-day SP year
 asterisk-form = "*"
 auth-param = token BWS "=" BWS ( token / quoted-string )


### PR DESCRIPTION
Clarify that Accept-Ranges can be sent by any server, remove "none" from the ABNF because it is now a reserved range unit, and allow the field to be sent in a trailer section while noting why that is much less useful than as a header field

For #857 

this is an alternative to #882 

