### PR TITLE
remove mention of obs-fold line folding from semantics

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -3226,6 +3226,7 @@ Connection: close
    <li>In <xref target="status.line"/>, rephrase text about status code definitions in <xref target="HTTP"/> (<eref target="https://github.com/httpwg/http-core/issues/915"/>)</li>
    <li>In <xref target="associating.response.to.request"/>, clarify how to match responses to requests (<eref target="https://github.com/httpwg/http-core/issues/915"/>)</li>
    <li>Made reference to <xref target="RFC5322"/> normative, as it is referenced from the ABNF (for "From" header field) (<eref target="https://github.com/httpwg/http-core/issues/915"/>)</li>
+   <li>In <xref target="line.folding"/>, include text about message/http that previously was in <xref target="HTTP"/> (<eref target="https://github.com/httpwg/http-core/issues/923"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -899,7 +899,7 @@ http://www.example.org:8080
 <section title="Obsolete Line Folding" anchor="line.folding">
   <x:anchor-alias value="obs-fold"/>
 <t>
-   Historically, HTTP field line values could be extended over multiple
+   Historically, HTTP/1.x field values could be extended over multiple
    lines by preceding each extra line with at least one space or horizontal
    tab (obs-fold). This specification deprecates such line folding except
    within the message/http media type
@@ -1983,7 +1983,12 @@ Connection: close
 <t>
    The message/http media type can be used to enclose a single HTTP request or
    response message, provided that it obeys the MIME restrictions for all
-   "message" types regarding line length and encodings.
+   "message" types regarding line length and encodings. Because of the line
+   length limitations, field values within message/http are allowed to use
+   line folding (<x:ref>obs-fold</x:ref>), as described in
+   <xref target="line.folding"/>, to convey the field value over multiple
+   lines. A recipient of message/http data &MUST; replace any obsolete line
+   folding with one or more SP characters when the message is consumed.
 </t>
 <dl>
   <dt>Type name:</dt>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13776,6 +13776,7 @@ Content-Type: text/plain
   <li>In <xref target="field.te"/>, add a forward reference to "weight" (<eref target="https://github.com/httpwg/http-core/issues/914"/>)</li>
   <li>In <xref target="field.accept-encoding"/>, clarify that the examples contains multiple values; also remove obsolete HTTP/1.0 note about qvalues (<eref target="https://github.com/httpwg/http-core/issues/914"/>)</li>
   <li>In <xref target="status.3xx"/>, remove incorrect mention of Etag as request field (<eref target="https://github.com/httpwg/http-core/issues/914"/>)</li>
+  <li>Move text about obs-fold in message/http to <xref target="HTTP11"/>; also note that LF is forbidden in field values just as CR and NUL (<eref target="https://github.com/httpwg/http-core/issues/923"/>)</li>
   <li>In <xref target="message.transformations"/>, properly refer to text that has moved to <xref target="HTTP11"/> (<eref target="https://github.com/httpwg/http-core/issues/930"/>)</li>
   <li>Rewrite description of validators and move cache-related aspects into <xref target="CACHING"/> (<eref target="https://github.com/httpwg/http-core/issues/933"/>)</li>
   <li>In <xref target="field.vary"/>, rephrase description to be more explanatory (<eref target="https://github.com/httpwg/http-core/issues/938"/>)</li>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -1701,18 +1701,19 @@ Example-Field: Baz
    through use of <xref target="RFC2047"/> encoding.
    Specifications for newly defined fields &SHOULD; limit their values to
    visible US-ASCII octets (VCHAR), SP, and HTAB.
-   A recipient &SHOULD; treat other octets in field content (obs-text) as
-   opaque data.
+   A recipient &SHOULD; treat other allowed octets in field content
+   (i.e., <x:ref>obs-text</x:ref>) as opaque data.
 </t>
 <t>
-   Field values containing CR or NUL characters are invalid and dangerous,
+   Field values containing CR, LF, or NUL characters are invalid and dangerous,
    due to the varying ways that implementations might parse and interpret
-   those characters; a recipient of CR or NUL within a field value &MUST;
+   those characters; a recipient of CR, LF, or NUL within a field value &MUST;
    either reject the message or replace each of those characters with SP
    before further processing or forwarding of that message. Field values
    containing other CTL characters are also invalid; however,
-   recipients &MAY; retain such characters for the sake of robustness if they
-   only appear within safe field value contexts (e.g., opaque data).
+   recipients &MAY; retain such characters for the sake of robustness when
+   they appear within a safe context (e.g., an application-specific quoted
+   string that will not be processed by any downstream HTTP parser).
 </t>
 <t><iref item="singleton field"/>
    Fields that only anticipate a single member as the field value are
@@ -1757,13 +1758,6 @@ Example-Dates: "Sat, 04 May 1996", "Wed, 14 Sep 2005"
    allows recipients to reuse existing parser components. When allowing both
    forms, the meaning of a parameter value ought to be the same whether it
    was received as a token or a quoted string.
-</t>
-<t>
-   Historically, HTTP field values could be extended over multiple lines by
-   preceding each extra line with at least one space or horizontal tab
-   (<x:ref>obs-fold</x:ref>). This document assumes that any such obsolete
-   line folding has been removed prior to interpreting the field value
-   (e.g., as described in <xref target="line.folding"/>).
 </t>
 <aside>
    <t>


### PR DESCRIPTION
… (now entirely handled by HTTP/1.1 messaging).
Include LF in discussion of what characters are invalid in field values.
Require obs-fold to be processed when consuming message/http data.

fixes #923 