### PR TITLE
Wordsmith the TLS secure close depiction

### DIFF
--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1926,7 +1926,7 @@ Connection: close
 <section title="TLS Connection Closure" anchor="tls.connection.closure">
 <t>
    TLS uses an exchange of closure alerts prior to (non-error) connection
-   closure to provide secure connection closure <xref target="TLS13"/>.  When a
+   closure to provide secure connection closure; see <xref section="6.1" target="TLS13"/>.  When a
    valid closure alert is received, an implementation can be assured that no
    further data will be received on that connection.
 </t>

--- a/draft-ietf-httpbis-messaging-latest.xml
+++ b/draft-ietf-httpbis-messaging-latest.xml
@@ -1925,11 +1925,10 @@ Connection: close
 
 <section title="TLS Connection Closure" anchor="tls.connection.closure">
 <t>
-   TLS provides a facility for secure connection closure through an
-   exchange of closure alerts prior to closing a connection
-   <xref target="TLS13"/>. When a valid closure alert is received,
-   an implementation can be assured that no further data will be received
-   on that connection.
+   TLS uses an exchange of closure alerts prior to (non-error) connection
+   closure to provide secure connection closure <xref target="TLS13"/>.  When a
+   valid closure alert is received, an implementation can be assured that no
+   further data will be received on that connection.
 </t>
 <t>
    When an implementation knows that it has sent or received all the


### PR DESCRIPTION
Inspired by my ballot comments (#915 )
I started trying to write something about how it's required to send "close_notify" in normal connection shutdown, but didn't like how that worked, and ended up here.
I am not sure if I regressed in some other axes while improving on this one, though.