### PR TITLE
Wordsmith the discussion of RFC 3864 updates

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -11492,8 +11492,9 @@ Content-Type: text/plain
 <t>
    This specification updates the HTTP related aspects of the existing
    registration procedures for message header fields defined in <xref target="RFC3864"/>.
-   It defines both a new registration procedure and moves HTTP field
-   definitions into a separate registry.
+   It replaces the old procedures as they relate to HTTP, by defining a new
+   registration procedure and moving HTTP field definitions into a separate
+   registry.
 </t>
 <t>
    Please create a new registry as outlined in <xref


### PR DESCRIPTION
The follow-up discussion on #914 indicated that the nature of the updates to RFC 3864 is essentially a "partial obsoletes", which means that we do not want to be part of BCP 90 even if we could -- we're carving off a piece of it and branching out on our own.  This PR attempts to reword the description slightly to indicate that we're not just tweaking part of RFC 3864, but rather replacing part of it (the parts that relate to HTTP), hopefully without bloating the text too much.