### PR TITLE
Avoid bare 'for the sake of security'

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -818,9 +818,9 @@
    other requests might require translation to and from entirely different
    application-level protocols. Proxies are often used to group an
    organization's HTTP requests through a common intermediary for the
-   sake of security, annotation services, or shared caching. Some proxies
-   are designed to apply transformations to selected messages or content
-   while they are being forwarded, as described in
+   sake of security services, annotation services, or shared caching. Some
+   proxies are designed to apply transformations to selected messages or
+   content while they are being forwarded, as described in
    <xref target="message.transformations"/>.
 </t>
 <t><iref primary="true" item="gateway"/><iref primary="true" item="reverse proxy"/>


### PR DESCRIPTION
Inspired by some discussion on #914 : while just the word "security"
is indeed used in marketing literature for proxies, it's meaning to different
parties is so varied so as to not really convey much useful information.  In the
IETF we try hard to be clear about what security provides we need and/or provide,
avoiding the vague catch-all term.  However (as I am reminded out of band), the
audience of this document is not exactly security experts, and it is easy to go
overboard trying to be precise, at least in this instance.

[actual commit message body retained below]

The mere act of inserting a proxy into the chain does not, in and of
itself, do much of anything for the security of the system (and a badly
implemented proxy can make the security of the system much worse).
A proxy can, however, provide security services such as auditing
access, annotating content from untrustworthy sources, exfiltration
avoidance, etc.  It is these services that are the security-related
motivation for using a proxy, so say that "security services", rather
than just "security", are being provided by the proxy.