### PR TITLE
Wordsmith future guidance on reactive negotiation

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -6417,7 +6417,7 @@ WWW-Authenticate: Basic realm="simple", Newauth realm="apps",
    latency if transmitted in the header section, and needing a second request
    to obtain an alternate representation. Furthermore, this specification
    does not define a mechanism for supporting automatic selection, though it
-   does not prevent such a mechanism from being developed as an extension.
+   does not prevent such a mechanism from being developed.
 </t>
 </section>
 


### PR DESCRIPTION
It may or may not be useful to have an HTTP extension in order to
perform reactive negotiation -- one possible approach that does not
require an extension would be policy in the user-agent.

In the spirit of "less is more", and to not overly constrain our
forward-looking statement, just remove the phrase "as an extension".

(inspired by follow-up discussions on #914)