### PR TITLE
wordsmith automatic-link-editing guidance

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -13836,6 +13836,7 @@ Content-Type: text/plain
 <ul x:when-empty="None yet.">
   <li>In <xref target="field.accept"/>, align text about "q" parameter with recent changes to IANA media types registry,
   and instruct IANA to reference this document with respect to the "q" special case (<eref target="https://github.com/httpwg/http-core/issues/970"/>)</li>
+  <li>In <xref target="status.301"/> and <xref target="status.308"/>, improve text about automatic link-editing (<eref target="https://github.com/httpwg/http-core/pull/976"/>)</li>
 </ul>
 </section>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -9046,9 +9046,12 @@ Content-Range: bytes 7000-7999/8000
    The <x:dfn>301 (Moved Permanently)</x:dfn> status code indicates that the
    <x:ref>target resource</x:ref> has been assigned a new permanent URI and
    any future references to this resource ought to use one of the enclosed
-   URIs. Clients with link-editing capabilities ought to automatically re-link
-   references to the target URI to one or more of the new
-   references sent by the server, where possible.
+   URIs. The server is suggesting that a user agent with link-editing capability
+   can permanently replace references to the target URI with one of the
+   new references sent by the server. However, this suggestion is usually
+   ignored unless the user agent is actively editing references
+   (e.g., engaged in authoring content), the connection is secured, and
+   the origin server is a trusted authority for the content being edited.
 </t>
 <t>
    The server &SHOULD; generate a <x:ref>Location</x:ref> header field in the

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -9233,7 +9233,7 @@ Content-Range: bytes 7000-7999/8000
    any future references to this resource ought to use one of the enclosed
    URIs. Clients with link editing capabilities ought to automatically re-link
    references to the target URI
-   to one or more of the new references sent by the server, where possible.
+   to one or more of the new references sent by the server, where appropriate.
 </t>
 <t>
    The server &SHOULD; generate a <x:ref>Location</x:ref> header field in the

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -9231,9 +9231,12 @@ Content-Range: bytes 7000-7999/8000
    The <x:dfn>308 (Permanent Redirect)</x:dfn> status code indicates that the
    <x:ref>target resource</x:ref> has been assigned a new permanent URI and
    any future references to this resource ought to use one of the enclosed
-   URIs. Clients with link editing capabilities ought to automatically re-link
-   references to the target URI
-   to one or more of the new references sent by the server, where appropriate.
+   URIs. The server is suggesting that a user agent with link-editing capability
+   can permanently replace references to the target URI with one of the
+   new references sent by the server. However, this suggestion is usually
+   ignored unless the user agent is actively editing references
+   (e.g., engaged in authoring content), the connection is secured, and
+   the origin server is a trusted authority for the content being edited.
 </t>
 <t>
    The server &SHOULD; generate a <x:ref>Location</x:ref> header field in the


### PR DESCRIPTION
The current text of "ought to ... where possible" is easy to read
as saying "if you have the technical capability, do it".
There are, however, some subtleties, such as if you get the 308 response
over http-not-s, in which case the question of whether or not to
re-link is not so clear-cut.

Change from "where possible" to "where appropriate" to hint that there
is some logic needed here beyond "blindly accept".

(inspired by follow-up discussions from #914)