### PR TITLE
strawman for referencing the URI security considerations

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -10470,7 +10470,7 @@ Content-Type: text/plain
    received via HTTP, or secure use of the Internet in general, rather than
    security of the protocol. The security considerations for URIs, which
    are fundamental to HTTP operation, are discussed in
-   <xref target="URI" x:fmt="," x:sec="7"/>. Various organizations maintain
+   <xref target="URI" x:fmt="of" x:sec="7"/>. Various organizations maintain
    topical information and links to current research on Web application
    security (e.g., <xref target="OWASP"/>).
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -10468,8 +10468,8 @@ Content-Type: text/plain
    related to HTTP semantics are about securing server-side applications (code
    behind the HTTP interface), securing user agent processing of content
    received via HTTP, or secure use of the Internet in general, rather than
-   security of the protocol. URIs are fundamental to HTTP operation; the
-   security considerations of URIs are discussed in
+   security of the protocol. The security considerations for URIs, which
+   are fundamental to HTTP operation, are discussed in
    <xref target="URI" x:fmt="," x:sec="7"/>. Various organizations maintain
    topical information and links to current research on Web application
    security (e.g., <xref target="OWASP"/>).

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -10468,9 +10468,11 @@ Content-Type: text/plain
    related to HTTP semantics are about securing server-side applications (code
    behind the HTTP interface), securing user agent processing of content
    received via HTTP, or secure use of the Internet in general, rather than
-   security of the protocol. Various organizations maintain topical
-   information and links to current research on Web application security
-   (e.g., <xref target="OWASP"/>).
+   security of the protocol. URIs are fundamental to HTTP operation; the
+   security considerations of URIs are discussed in
+   <xref target="URI" x:fmt="," x:sec="7"/>. Various organizations maintain
+   topical information and links to current research on Web application
+   security (e.g., <xref target="OWASP"/>).
 </t>
 
 <section title="Establishing Authority" anchor="establishing.authority">


### PR DESCRIPTION
Inspired by follow-up discussions on #914 , make a concrete proposal for how the RFC 3986 security considerations might be mentioned in our own security considerations.
I understand the editors' stance on adding substantial new text at this point, and will defer to them on whether this constitutes "substantial".