### PR TITLE
clarify handling of invalid or unsatisfiable range requests

### DIFF
--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7731,8 +7731,8 @@ If-Unmodified-Since: Sat, 29 Oct 1994 19:43:31 GMT
 </t>
 
 <section title="Range Specifiers" anchor="range.specifiers">
-  <iref primary="true" item="satisfiable"/>
-  <iref primary="true" item="unsatisfiable"/>
+  <iref primary="true" item="satisfiable range"/>
+  <iref primary="true" item="unsatisfiable range"/>
 <t>
    Ranges are expressed in terms of a range unit paired with a set of range
    specifiers. The range unit name determines what kinds of range-spec
@@ -7858,7 +7858,7 @@ bytes=500-999
    is one less than the current length of the selected representation).
 </t>
 <t>
-   A client can request the last N bytes (N &gt; 0) of the selected
+   A client can refer to the last N bytes (N &gt; 0) of the selected
    representation using a <x:ref>suffix-range</x:ref>.
    If the selected representation is shorter than the specified
    <x:ref>suffix-length</x:ref>, the entire representation is used.
@@ -7895,7 +7895,8 @@ bytes=500-700,601-999
    </li>
 </ul>
 <t>
-   A valid bytes <x:ref>range-spec</x:ref> is satisfiable if it is either:
+   For a <x:ref>GET</x:ref> request, a valid bytes <x:ref>range-spec</x:ref>
+   is <x:ref>satisfiable<x:ref> if it is either:
 </t>
 <ul>
    <li>an <x:ref>int-range</x:ref> with a <x:ref>first-pos</x:ref> that
@@ -7905,9 +7906,10 @@ bytes=500-700,601-999
        <x:ref>suffix-length</x:ref>.</li>
 </ul>
 <t>
-   If the selected representation has zero length, the only satisfiable form of
-   <x:ref>range-spec</x:ref> is a <x:ref>suffix-range</x:ref> with a non-zero
-   <x:ref>suffix-length</x:ref>.
+   When a selected representation has zero length, the only
+   <x:ref>satisfiable<x:ref> form of <x:ref>range-spec</x:ref> in a
+   <x:ref>GET</x:ref> request is a <x:ref>suffix-range</x:ref> with a
+   non-zero <x:ref>suffix-length</x:ref>.
 </t>
 <t>
    In the byte-range syntax, <x:ref>first-pos</x:ref>,

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7954,10 +7954,12 @@ bytes=500-700,601-999
 </t>
 <t>
    A server that supports range requests &MAY; ignore or reject a
-   <x:ref>Range</x:ref> header field that consists of more than two
-   overlapping ranges, or a set of many small ranges that are not listed
-   in ascending order, since both are indications of either a broken client or
-   a deliberate denial-of-service attack (<xref target="overlapping.ranges"/>).
+   <x:ref>Range</x:ref> header field that contains an invalid
+   <x:ref>ranges-specifier</x:ref> (<xref target="range.specifiers"/>),
+   a <x:ref>ranges-specifier</x:ref> with more than two overlapping ranges,
+   or a set of many small ranges that are not listed in ascending order,
+   since these are indications of either a broken client or a deliberate
+   denial-of-service attack (<xref target="overlapping.ranges"/>).
    A client &SHOULD-NOT; request multiple ranges that are inherently less
    efficient to process and transfer than a single range that encompasses the
    same data.
@@ -7990,10 +7992,10 @@ bytes=500-700,601-999
 <t>
    If all of the preconditions are true, the server supports the Range header
    field for the target resource, the received Range field-value contains a
-   valid <x:ref>ranges-specifier</x:ref> (<xref target="range.specifiers"/>)
-   with a <x:ref>range-unit</x:ref> supported for that target resource,
-   and that <x:ref>ranges-specifier</x:ref> is satisfiable with respect to
-   the selected representation,
+   valid <x:ref>ranges-specifier</x:ref> with a <x:ref>range-unit</x:ref>
+   supported for that target resource, and that
+   <x:ref>ranges-specifier</x:ref> is <x:ref>satisfiable</x:ref> with respect
+   to the selected representation,
    the server &SHOULD; send a <x:ref>206 (Partial Content)</x:ref> response
    with content containing one or more partial representations
    that correspond to the satisfiable <x:ref>range-spec</x:ref>(s) requested.
@@ -8004,12 +8006,6 @@ bytes=500-700,601-999
    the requested ranges first, while expecting the client to re-request the
    remaining portions later if they are still desired
    (see <xref target="status.206"/>).
-</t>
-<t>
-   If all of the preconditions are true, the server supports the Range header
-   field for the target resource, and the received Range field-value contains
-   an invalid <x:ref>ranges-specifier</x:ref>,
-   the server &SHOULD; send a <x:ref>400 (Bad Request)</x:ref> response.
 </t>
 <t>
    If all of the preconditions are true, the server supports the Range header

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7896,7 +7896,7 @@ bytes=500-700,601-999
 </ul>
 <t>
    For a <x:ref>GET</x:ref> request, a valid bytes <x:ref>range-spec</x:ref>
-   is <x:ref>satisfiable<x:ref> if it is either:
+   is <x:ref>satisfiable</x:ref> if it is either:
 </t>
 <ul>
    <li>an <x:ref>int-range</x:ref> with a <x:ref>first-pos</x:ref> that
@@ -7907,7 +7907,7 @@ bytes=500-700,601-999
 </ul>
 <t>
    When a selected representation has zero length, the only
-   <x:ref>satisfiable<x:ref> form of <x:ref>range-spec</x:ref> in a
+   <x:ref>satisfiable</x:ref> form of <x:ref>range-spec</x:ref> in a
    <x:ref>GET</x:ref> request is a <x:ref>suffix-range</x:ref> with a
    non-zero <x:ref>suffix-length</x:ref>.
 </t>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7717,6 +7717,8 @@ If-Unmodified-Since: Sat, 29 Oct 1994 19:43:31 GMT
 </t>
 
 <section title="Range Specifiers" anchor="range.specifiers">
+  <iref primary="true" item="satisfiable"/>
+  <iref primary="true" item="unsatisfiable"/>
 <t>
    Ranges are expressed in terms of a range unit paired with a set of range
    specifiers. The range unit name determines what kinds of range-spec
@@ -7781,6 +7783,18 @@ If-Unmodified-Since: Sat, 29 Oct 1994 19:43:31 GMT
   <x:ref>other-range</x:ref>   = 1*( %x21-2B / %x2D-7E )
                 ; 1*(VCHAR excluding comma)
 </sourcecode>
+<t>
+   A <x:ref>ranges-specifier</x:ref> is invalid if it contains any
+   <x:ref>range-spec</x:ref> that is invalid or undefined for the indicated
+   <x:ref>range-unit</x:ref>.
+</t>
+<t anchor="satisfiable">
+   A valid <x:ref>ranges-specifier</x:ref> is <x:dfn>satisfiable</x:dfn>
+   if it contains at least one <x:ref>range-spec</x:ref> that is
+   satisfiable, as defined by the indicated <x:ref>range-unit</x:ref>.
+   Otherwise, the <x:ref>ranges-specifier</x:ref> is
+   <x:dfn>unsatisfiable</x:dfn>.
+</t>
 </section>
 
 <section title="Byte Ranges" anchor="byte.ranges">
@@ -7867,13 +7881,15 @@ bytes=500-700,601-999
    </li>
 </ul>
 <t>
-   If a valid bytes <x:ref>range-set</x:ref> includes at least one
-   <x:ref>range-spec</x:ref> with a <x:ref>first-pos</x:ref> that is
-   less than the current length of the representation, or at least one
-   <x:ref>suffix-range</x:ref> with a non-zero <x:ref>suffix-length</x:ref>,
-   then the bytes <x:ref>range-set</x:ref> is satisfiable. Otherwise,
-   the bytes <x:ref>range-set</x:ref> is unsatisfiable.
+   A valid bytes <x:ref>range-spec</x:ref> is satisfiable if it is either:
 </t>
+<ul>
+   <li><t>an <x:ref>int-range</x:ref> with a <x:ref>first-pos</x:ref> that
+       is less than the current length of the selected representation;
+       or,</t></li>
+   <li><t>a <x:ref>suffix-range</x:ref> with a non-zero
+       <x:ref>suffix-length</x:ref>.</t></li>
+</ul>
 <t>
    If the selected representation has zero length, the only satisfiable form of
    <x:ref>range-spec</x:ref> is a <x:ref>suffix-range</x:ref> with a non-zero
@@ -7957,11 +7973,14 @@ bytes=500-700,601-999
 </t>
 <t>
    If all of the preconditions are true, the server supports the Range header
-   field for the target resource, and the specified range(s) are valid and
-   satisfiable (as defined in <xref target="byte.ranges"/>), the
-   server &SHOULD; send a <x:ref>206 (Partial Content)</x:ref> response with a
-   content containing one or more partial representations that correspond to
-   the satisfiable ranges requested.
+   field for the target resource, the received Range field-value contains a
+   valid <x:ref>ranges-specifier</x:ref> (<xref target="range.specifiers"/>)
+   with a <x:ref>range-unit</x:ref> supported for that target resource,
+   and that <x:ref>ranges-specifier</x:ref> is satisfiable with respect to
+   the selected representation,
+   the server &SHOULD; send a <x:ref>206 (Partial Content)</x:ref> response
+   with content containing one or more partial representations
+   that correspond to the satisfiable <x:ref>range-spec</x:ref>(s) requested.
 </t>
 <t>
    The above does not imply that a server will send all requested ranges.
@@ -7972,8 +7991,17 @@ bytes=500-700,601-999
 </t>
 <t>
    If all of the preconditions are true, the server supports the Range header
-   field for the target resource, and the specified range(s) are invalid or
-   unsatisfiable, the server &SHOULD; send a
+   field for the target resource, and the received Range field-value contains
+   an invalid <x:ref>ranges-specifier</x:ref>,
+   the server &SHOULD; send a <x:ref>400 (Bad Request)</x:ref> response.
+</t>
+<t>
+   If all of the preconditions are true, the server supports the Range header
+   field for the target resource, the received Range field-value contains a
+   valid <x:ref>ranges-specifier</x:ref>, and either the
+   <x:ref>range-unit</x:ref> is not supported for that target resource or
+   the <x:ref>ranges-specifier</x:ref> is unsatisfiable with respect to
+   the selected representation, the server &SHOULD; send a
    <x:ref>416 (Range Not Satisfiable)</x:ref> response.
 </t>
 </section>

--- a/draft-ietf-httpbis-semantics-latest.xml
+++ b/draft-ietf-httpbis-semantics-latest.xml
@@ -7884,11 +7884,11 @@ bytes=500-700,601-999
    A valid bytes <x:ref>range-spec</x:ref> is satisfiable if it is either:
 </t>
 <ul>
-   <li><t>an <x:ref>int-range</x:ref> with a <x:ref>first-pos</x:ref> that
+   <li>an <x:ref>int-range</x:ref> with a <x:ref>first-pos</x:ref> that
        is less than the current length of the selected representation;
-       or,</t></li>
-   <li><t>a <x:ref>suffix-range</x:ref> with a non-zero
-       <x:ref>suffix-length</x:ref>.</t></li>
+       or,</li>
+   <li>a <x:ref>suffix-range</x:ref> with a non-zero
+       <x:ref>suffix-length</x:ref>.</li>
 </ul>
 <t>
    If the selected representation has zero length, the only satisfiable form of


### PR DESCRIPTION
Fixes #1011 

This is longer than I wanted but has the benefit of defining a satisfiable ranges-specifier in general (instead of only for bytes requests), how to handle an invalid ranges-specifier as a bad request, and defines which code to use for an unsupported range-unit.

I believe all of this was implied by the existing text and how we have used valid/invalid, but I think it is clearer stated this way instead of the prior generalizations.

YMMV. This probably should be reviewed by the WG (just to be sure).